### PR TITLE
Ported ConcurrentOperationRegistry from GT and added operation substitution

### DIFF
--- a/jt-affine/src/main/resources/META-INF/registryFile.jai
+++ b/jt-affine/src/main/resources/META-INF/registryFile.jai
@@ -8,4 +8,4 @@ descriptor  it.geosolutions.jaiext.affine.AffineDescriptor
 # RenderedImageFactories
 #
 
-rendered  it.geosolutions.jaiext.affine.AffineCRIF  it.geosolutions.jaiext  AffineNoData AffineNoData 
+rendered  it.geosolutions.jaiext.affine.AffineCRIF  it.geosolutions.jaiext  AffineNoData AffineNoData

--- a/jt-utilities/pom.xml
+++ b/jt-utilities/pom.xml
@@ -33,5 +33,11 @@
 			<version>${guava.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>${apache.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/ConcurrentOperationRegistry.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/ConcurrentOperationRegistry.java
@@ -1,0 +1,1217 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+*    http://www.geo-solutions.it/
+ *    Copyright 2014 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.geosolutions.jaiext;
+
+import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
+import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
+import it.geosolutions.jaiext.interpolators.InterpolationNearest;
+
+import java.awt.image.renderable.ParameterBlock;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.media.jai.Interpolation;
+import javax.media.jai.JAI;
+import javax.media.jai.OperationDescriptor;
+import javax.media.jai.OperationNode;
+import javax.media.jai.OperationRegistry;
+import javax.media.jai.PropertyGenerator;
+import javax.media.jai.PropertySource;
+import javax.media.jai.RegistryElementDescriptor;
+import javax.media.jai.registry.RenderedRegistryMode;
+import javax.media.jai.util.ImagingException;
+import javax.media.jai.util.ImagingListener;
+
+import com.sun.media.jai.util.PropertyUtil;
+
+/**
+ * A thread safe implementation of OperationRegistry using Java 5 Concurrent {@link ReadWriteLock}
+ * Also it is able to substitute JAI operations with JAI-EXT ones and vice versa.
+ * 
+ * @author Andrea Aime - GeoSolutions
+ * @author Nicola Lagomarsini - GeoSolutions
+ */
+public final class ConcurrentOperationRegistry extends OperationRegistry {
+    /** Path to the JAI default registryfile.jai */
+    static String JAI_REGISTRY_FILE = "META-INF/javax.media.jai.registryFile.jai";
+
+    /** Name of the other registryfile.jai */
+    static String USR_REGISTRY_FILE = "META-INF/registryFile.jai";
+
+    /** String associated to the vendor key */
+    static final String VENDOR_NAME = "Vendor";
+
+    /** String associated to the JAIEXT product */
+    static final String JAIEXT_PRODUCT = "it.geosolutions.jaiext";
+
+    /** String associated to the JAI product */
+    static final String JAI_PRODUCT = "com.sun.media.jai";
+
+    /** String associated to the JAI product when the operation is "Null" */
+    static final String JAI_PRODUCT_NULL = "javax.media.jai";
+
+    /** Logger associated to the class*/
+    private static final Logger LOGGER = Logger.getLogger(ConcurrentOperationRegistry.class.toString());
+
+    public static OperationRegistry initializeRegistry() {
+        try {
+            // URL associated to the default JAI registryfile.jai
+            InputStream url = PropertyUtil.getFileFromClasspath(JAI_REGISTRY_FILE);
+
+            if (url == null) {
+                throw new RuntimeException("Could not find the main registry file");
+            }
+            // Creation of a new registry
+            ConcurrentOperationRegistry registry = new ConcurrentOperationRegistry();
+            // Registration of the JAI operations
+            if (url != null) {
+                registry.updateFromStream(url);
+            }
+            // Registration of the operation defined in any registryFile.jai file
+            registry.registerServices(null);
+            // Listing of all the registered operations
+            List<OperationDescriptor> descriptors = registry
+                    .getDescriptors(RenderedRegistryMode.MODE_NAME);
+            // Creation of a new OperationCollection object
+            OperationCollection input = new OperationCollection(registry);
+            input.createMapFromDescriptors(descriptors);
+            // Saving of the all initial operations
+            registry.jaiMap = input.copy().map;
+
+            // First load all the REGISTRY_FILEs that are found in
+            // the specified class loader.
+            Enumeration<URL> en = ClassLoader.getSystemResources(USR_REGISTRY_FILE);
+            // Creation of another OperationCollection instance to use for storing all the 
+            OperationCollection changed = new OperationCollection(registry);
+            // Loop on all the registryFile.jai files
+            while (en.hasMoreElements()) {
+                URL url1 = en.nextElement();
+                changed.add(RegistryFileParser.parseFile(null, url1));
+            }
+            // Filter only the JAIEXT operations
+            changed = changed.filter(JAIEXT_PRODUCT);
+            // Copy the available JAIEXT operations
+            registry.jaiExtMap = changed.copy().map;
+            // Substitute the JAIEXT operations
+            input.substituteOperations(changed);
+            // Set the Collection inside the registry file
+            registry.setOperationCollection(input);
+            // Return the registry
+            return registry;
+
+        } catch (IOException ioe) {
+            ImagingListener listener = JAI.getDefaultInstance().getImagingListener();
+            String message = "Error occurred while initializing JAI";
+            listener.errorOccurred(message, new ImagingException(message, ioe),
+                    OperationRegistry.class, false);
+
+            return null;
+        }
+    }
+
+    /** The reader/writer lock for this class. */
+    private ReadWriteLock lock;
+
+    /** Collection of the registered Operations */
+    OperationCollection collection;
+
+    /** Map of the JAI operations */
+    private Map<String, OperationItem> jaiMap;
+
+    /** Map of the JAI-EXT operations */
+    private Map<String, OperationItem> jaiExtMap;
+
+    public ConcurrentOperationRegistry() {
+        super();
+
+        // Create a concurrent RW lock.
+        lock = new ReentrantReadWriteLock();
+    }
+
+    public String toString() {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.toString();
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public void writeToStream(OutputStream out) throws IOException {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+            super.writeToStream(out);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public void initializeFromStream(InputStream in) throws IOException {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.initializeFromStream(in);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void updateFromStream(InputStream in) throws IOException {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.updateFromStream(in);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.readExternal(in);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+            super.writeExternal(out);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public void removeRegistryMode(String modeName) {
+
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.removeRegistryMode(modeName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public String[] getRegistryModes() {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getRegistryModes();
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public void registerDescriptor(RegistryElementDescriptor descriptor) {
+        Lock writeLock = lock.writeLock();
+        boolean changed = false;
+        try {
+            writeLock.lock();
+            super.registerDescriptor(descriptor);
+            changed = true;
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, "Registered descriptor for the operation: "
+                        + descriptor.getName());
+            }
+        }finally {
+            // If the collection is present, then it is updated
+            if(collection != null && changed && descriptor instanceof OperationDescriptor){
+                OperationItem item = new OperationItem((OperationDescriptor) descriptor);
+                collection.substituteSingleOp(item);
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "Added descriptor for the operation: "
+                            + descriptor.getName()  + " to the registry operation list");
+                }
+            }
+            writeLock.unlock();
+        }
+    }
+
+    public void unregisterDescriptor(RegistryElementDescriptor descriptor) {
+
+        Lock writeLock = lock.writeLock();
+        boolean changed = false;
+        try {
+            writeLock.lock();
+            super.unregisterDescriptor(descriptor);
+            changed = true;
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, "Unregistered descriptor for the operation: "
+                        + descriptor.getName());
+            }
+        } finally {
+            // If the collection is present, then it is updated
+            if(collection != null && changed && descriptor instanceof OperationDescriptor){
+                OperationItem item = new OperationItem((OperationDescriptor) descriptor);
+                collection.removeSingleOp(item);
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "Removed descriptor for the operation: "
+                            + descriptor.getName()  + " from the registry operation list");
+                }
+            }
+            writeLock.unlock();
+        }
+    }
+
+    public RegistryElementDescriptor getDescriptor(Class descriptorClass, String descriptorName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getDescriptor(descriptorClass, descriptorName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public List getDescriptors(Class descriptorClass) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getDescriptors(descriptorClass);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public String[] getDescriptorNames(Class descriptorClass) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getDescriptorNames(descriptorClass);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public RegistryElementDescriptor getDescriptor(String modeName, String descriptorName) {
+
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getDescriptor(modeName, descriptorName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public List getDescriptors(String modeName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getDescriptors(modeName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public String[] getDescriptorNames(String modeName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getDescriptorNames(modeName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public void setProductPreference(String modeName, String descriptorName,
+            String preferredProductName, String otherProductName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.setProductPreference(modeName, descriptorName, preferredProductName,
+                    otherProductName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void unsetProductPreference(String modeName, String descriptorName,
+            String preferredProductName, String otherProductName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.unsetProductPreference(modeName, descriptorName, preferredProductName,
+                    otherProductName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void clearProductPreferences(String modeName, String descriptorName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.clearProductPreferences(modeName, descriptorName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public String[][] getProductPreferences(String modeName, String descriptorName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getProductPreferences(modeName, descriptorName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Vector getOrderedProductList(String modeName, String descriptorName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getOrderedProductList(modeName, descriptorName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public void registerFactory(String modeName, String descriptorName, String productName,
+            Object factory) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.registerFactory(modeName, descriptorName, productName, factory);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, "Registered factory for the operation: "
+                        + descriptorName);
+            }
+            // If the collection is present, then it is updated
+            if(collection != null && modeName.equalsIgnoreCase(RenderedRegistryMode.MODE_NAME)){
+                collection.substituteFactory(factory, descriptorName, productName); 
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "Added factory for the operation: "
+                            + descriptorName  + " to the registry operation list");
+                }
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void unregisterFactory(String modeName, String descriptorName, String productName,
+            Object factory) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.unregisterFactory(modeName, descriptorName, productName, factory);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, "Unregistered factory for the operation: "
+                        + descriptorName);
+            }
+            // If the collection is present, then it is updated
+            if(collection != null && modeName.equalsIgnoreCase(RenderedRegistryMode.MODE_NAME)){
+                collection.removeFactory(factory, descriptorName, productName); 
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "Removed factory for the operation: "
+                            + descriptorName  + " from the registry operation list");
+                }
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void setFactoryPreference(String modeName, String descriptorName, String productName,
+            Object preferredOp, Object otherOp) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.setFactoryPreference(modeName, descriptorName, productName, preferredOp, otherOp);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void unsetFactoryPreference(String modeName, String descriptorName, String productName,
+            Object preferredOp, Object otherOp) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.unsetFactoryPreference(modeName, descriptorName, productName, preferredOp,
+                    otherOp);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void clearFactoryPreferences(String modeName, String descriptorName, String productName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.clearFactoryPreferences(modeName, descriptorName, productName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public Object[][] getFactoryPreferences(String modeName, String descriptorName,
+            String productName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getFactoryPreferences(modeName, descriptorName, productName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public List getOrderedFactoryList(String modeName, String descriptorName, String productName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getOrderedFactoryList(modeName, descriptorName, productName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Iterator getFactoryIterator(String modeName, String descriptorName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getFactoryIterator(modeName, descriptorName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Object getFactory(String modeName, String descriptorName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getFactory(modeName, descriptorName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Object invokeFactory(String modeName, String descriptorName, Object[] args) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+            // For Rendered Mode, a check on the interpolations objects is made
+            // in order to convert each eventual JAI-EXT interpolation class
+            // if the Factory belongs to the JAI API
+            if(modeName.equalsIgnoreCase(RenderedRegistryMode.MODE_NAME)){
+                checkInterpolation(descriptorName, args);
+            }
+
+            return super.invokeFactory(modeName, descriptorName, args);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public void addPropertyGenerator(String modeName, String descriptorName,
+            PropertyGenerator generator) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.addPropertyGenerator(modeName, descriptorName, generator);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void removePropertyGenerator(String modeName, String descriptorName,
+            PropertyGenerator generator) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.removePropertyGenerator(modeName, descriptorName, generator);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void copyPropertyFromSource(String modeName, String descriptorName, String propertyName,
+            int sourceIndex) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.copyPropertyFromSource(modeName, descriptorName, propertyName, sourceIndex);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void suppressProperty(String modeName, String descriptorName, String propertyName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.suppressProperty(modeName, descriptorName, propertyName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void suppressAllProperties(String modeName, String descriptorName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.suppressAllProperties(modeName, descriptorName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void clearPropertyState(String modeName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.clearPropertyState(modeName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public String[] getGeneratedPropertyNames(String modeName, String descriptorName) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getGeneratedPropertyNames(modeName, descriptorName);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public PropertySource getPropertySource(String modeName, String descriptorName, Object op,
+            Vector sources) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getPropertySource(modeName, descriptorName, op, sources);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public PropertySource getPropertySource(OperationNode op) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+
+            return super.getPropertySource(op);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public void registerServices(ClassLoader cl) throws IOException {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.registerServices(cl);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void unregisterOperationDescriptor(String operationName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.unregisterOperationDescriptor(operationName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void clearOperationPreferences(String operationName, String productName) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            super.clearOperationPreferences(operationName, productName);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Sets the {@link OperationCollection} containing the list of all the operations contained by the registry.
+     * 
+     * @param coll
+     */
+    public void setOperationCollection(OperationCollection coll) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            this.collection = coll;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * This method returns an {@link OperationCollection} object containing all the registered operations.
+     * 
+     * @return
+     */
+    OperationCollection getOperationCollection() {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+            return collection;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Returns a {@link Collection} object containing a view of the {@link OperationCollection} inside the registry.
+     * 
+     * @return
+     */
+    public Collection<OperationItem> getOperations() {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+            return collection.getOperations();
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Returns a Map containing the {@link OperationItem} objects for each operation. The jai parameter indicates whether must be returned the map of
+     * the jai operations or of the Jai-ext ones.
+     * 
+     * @param jai
+     * @return
+     */
+    public Map<String, OperationItem> getOperationMap(boolean jai) {
+        Lock readLock = lock.readLock();
+        try {
+            readLock.lock();
+            if (jai) {
+                return jaiMap;
+            } else {
+                return jaiExtMap;
+            }
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * This method internally check if the descriptor used is a
+     * 
+     * @param descriptorName
+     * @param args
+     */
+    void checkInterpolation(String descriptorName, Object[] args) {
+        // First check if the collection is present and then get the OperationItem associated
+        OperationItem item = null;
+        if (collection != null) {
+            item = collection.get(descriptorName);
+        }
+        // By default we do not change the Interpolation
+        boolean jaiext = true;
+        // If the item is present we check if it belongs to jaiext
+        if (item != null) {
+            jaiext = item.isJAIEXTProduct();
+        } else {
+            // Else we check the Descriptor vendor parameter
+            OperationDescriptor op = (OperationDescriptor) getDescriptor(
+                    RenderedRegistryMode.MODE_NAME, descriptorName);
+            String vendor = op.getResourceBundle(null).getString(VENDOR_NAME);
+            jaiext = vendor.equalsIgnoreCase(JAIEXT_PRODUCT);
+        }
+        // If the operation is not a JAI-EXT one then we start to check if there is any Interpolation
+        // instance
+        if (!jaiext) {
+            // Cycle on the parameterBlock parameters
+            ParameterBlock block = (ParameterBlock) args[0];
+            Vector<Object> params = block.getParameters();
+            int index = 0;
+            for (Object param : params) {
+                if (param instanceof Interpolation) {
+                    Interpolation interp = null;
+                    // If the parameter is an instance of one of the JAI-EXT Interpolation classes
+                    // then it is transformed into the related JAI Interpolation class.
+                    if (param instanceof InterpolationNearest) {
+                        interp = new javax.media.jai.InterpolationNearest();
+                    } else if (param instanceof InterpolationBilinear) {
+                        InterpolationBilinear bil = (InterpolationBilinear) param;
+                        interp = new javax.media.jai.InterpolationBilinear(bil.getSubsampleBitsH());
+                    } else if (param instanceof InterpolationBicubic) {
+                        InterpolationBicubic bic = (InterpolationBicubic) param;
+                        if (bic.isBicubic2()) {
+                            interp = new javax.media.jai.InterpolationBicubic2(
+                                    bic.getSubsampleBitsH());
+                        } else {
+                            interp = new javax.media.jai.InterpolationBicubic(
+                                    bic.getSubsampleBitsH());
+                        }
+                    }
+                    if (interp != null) {
+                        block.set(interp, index);
+                        if (LOGGER.isLoggable(Level.FINEST)) {
+                            LOGGER.log(Level.FINEST, "Converted JAI-EXT Interpolation object to JAI one");
+                        }
+                    }
+                    break;
+                }
+                index++;
+            }
+        }
+    }
+
+    /**
+     * The {@link OperationItem} class is a wrapper for the {@link OperationDescriptor} class which can store informations about the operations and
+     * the associated factory.
+     * 
+     * @author Nicola Lagomarsini GeoSolutions S.A.S.
+     * 
+     */
+    public static class OperationItem {
+        /** {@link OperationDescriptor} instance associated to the operation */
+        private OperationDescriptor op;
+
+        /** Descriptor vendor name */
+        private String vendor;
+
+        /** Operation Name */
+        private String opName;
+
+        /** Factory object (May be null) */
+        private Object factory;
+
+        /** MediaLib Factory object, used by JAI. (May be null) */
+        private Object mlibFactory;
+
+        /** Boolean indicating if the MediaLib acceleration must be used. By default is set to false */
+        private boolean isMediaLibPreferred;
+
+        public OperationItem(OperationDescriptor op) {
+            this.op = op;
+            this.opName = op.getName();
+            this.vendor = op.getResourceBundle(null).getString(VENDOR_NAME);
+            this.isMediaLibPreferred = false;
+        }
+
+        public OperationItem(OperationItem item) {
+            this.op = item.getDescriptor();
+            this.opName = item.getName();
+            this.vendor = item.getVendor();
+            this.factory = item.getFactory();
+            this.mlibFactory = item.getMlibFactory();
+            this.isMediaLibPreferred = item.isMediaLibPreferred;
+        }
+
+        public String getVendor() {
+            return vendor;
+        }
+
+        public String getName() {
+            return opName;
+        }
+
+        public OperationDescriptor getDescriptor() {
+            return op;
+        }
+
+        /***
+         * Returns the factory defined by the user. If medialib is preferred, then the MediaLib factory is returned, otherwise the JAI default factory
+         * is returned.
+         * 
+         * @return
+         */
+        public Object getCurrentFactory() {
+            if (mlibFactory != null && isMediaLibPreferred) {
+                return mlibFactory;
+            }
+            return factory;
+        }
+
+        public Object getFactory() {
+            return factory;
+        }
+
+        public Object getMlibFactory() {
+            return mlibFactory;
+        }
+
+        public OperationDescriptor getOp() {
+            return op;
+        }
+
+        public boolean isMediaLibPreferred() {
+            return isMediaLibPreferred;
+        }
+
+        public void setFactory(Object factory) {
+            this.factory = factory;
+        }
+
+        public void setMlibFactory(Object factory) {
+            this.mlibFactory = factory;
+        }
+
+        public void setMlibPreference(boolean preferred) {
+            this.isMediaLibPreferred = preferred;
+        }
+
+        /**
+         * Indicates if the {@link OperationItem} operation is a JAI-EXT one
+         * 
+         * @return
+         */
+        public boolean isJAIEXTProduct() {
+            return vendor.equalsIgnoreCase(JAIEXT_PRODUCT);
+        }
+    }
+
+    /**
+     * This class is a container class which stores internally all the {@link OperationItem}s, each one for an {@link OperationDescriptor}. This class
+     * contains all the operations inside an inner map and provides some utility methods for using it.
+     * 
+     * @author Nicola Lagomarsini GeoSolutions S.A.S.
+     * 
+     */
+    static class OperationCollection {
+        /** Inner Map containing all the {@link OperationItem}s for each operation */
+        private Map<String, OperationItem> map = new ConcurrentHashMap<String, OperationItem>();
+
+        /** {@link OperationRegistry} used by the collection for registering and unregistering operations */
+        private OperationRegistry registry;
+
+        public OperationCollection(OperationRegistry registry, Map<String, OperationItem> map) {
+            this.map = map;
+            this.registry = registry;
+        }
+
+        public OperationCollection(OperationRegistry registry) {
+            this.registry = registry;
+        }
+
+        /**
+         * This method copies all the values inside a new {@link OperationCollection} instance
+         */
+        public OperationCollection copy() {
+            Collection<OperationItem> values = map.values();
+            OperationCollection newColl = new OperationCollection(registry);
+            for (OperationItem item : values) {
+                newColl.add(new OperationItem(item));
+            }
+            return newColl;
+        }
+
+        /**
+         * This method populates the inner map with a List of {@link OperationDescriptor}s.
+         * 
+         * @param listDesc
+         */
+        public void createMapFromDescriptors(List<OperationDescriptor> listDesc) {
+            for (OperationDescriptor desc : listDesc) {
+                OperationItem value = createItem(desc);
+                map.put(desc.getName(), value);
+            }
+        }
+
+        /**
+         * This method returns a new {@link OperationCollection} instance filtered by the vendor name.
+         * 
+         * @param vendor
+         * @return
+         */
+        public OperationCollection filter(String vendor) {
+            Collection<OperationItem> values = map.values();
+            OperationCollection filtered = new OperationCollection(registry);
+            for (OperationItem item : values) {
+                if (item.getVendor().equalsIgnoreCase(vendor)) {
+                    filtered.map.put(item.getName(), item);
+                }
+            }
+            return filtered;
+        }
+
+        /**
+         * Add a new Item to the map.
+         * 
+         * @param item
+         */
+        public void add(OperationItem item) {
+            map.put(item.getName(), item);
+        }
+
+        /**
+         * Add the contents of an external map inside the inner map.
+         * 
+         * @param items
+         */
+        public void add(Map<String, OperationItem> items) {
+            map.putAll(items);
+        }
+
+        /**
+         * Returns the {@link OperationItem} associated to the input operation name.
+         * 
+         * @param decriptorname
+         * @return
+         */
+        public OperationItem get(String decriptorname) {
+            return map.get(decriptorname);
+        }
+
+        /**
+         * Returns a view of the all the {@link OperationItem}s contained by the map.
+         * 
+         * @return
+         */
+        public Collection<OperationItem> getOperations() {
+            return map.values();
+        }
+
+        /**
+         * Creates a new {@link OperationItem} from an {@link OperationDescriptor}.
+         * 
+         * @param desc
+         * @return
+         */
+        public OperationItem createItem(OperationDescriptor desc) {
+
+            OperationItem value = new OperationItem(desc);
+            // Selection of a List of the Factories associated to the operation and the vendor
+            List<Object> list = registry.getOrderedFactoryList(RenderedRegistryMode.MODE_NAME,
+                    desc.getName(), value.getVendor());
+            // If the List is not null then we start iterating on it.
+            if (list != null) {
+                // If there is the MediaLib factory, it is saved inside the OperationItem
+                // but it is not used by default
+                for (Object factory : list) {
+                    if (factory.getClass().getName().contains("Mlib")) {
+                        value.setMlibFactory(factory);
+                    } else {
+                        value.setFactory(factory);
+                        break;
+                    }
+                }
+            }
+            return value;
+        }
+
+        /**
+         * This method substitutes all the operations contained by an external {@link OperationCollection} inside the current
+         * {@link OperationCollection}.
+         * 
+         * @param changedOps
+         */
+        void substituteOperations(OperationCollection changedOps) {
+            // Selection of all the operations of the external OperationCollection
+            Map<String, OperationItem> mapChanged = changedOps.map;
+            Collection<OperationItem> items = mapChanged.values();
+            // Iteration on all the new operations and registration of them
+            for (OperationItem item : items) {
+                substituteDescriptors(item);
+                // Insert the new Item inside the map
+                map.put(item.getName(), item);
+            }
+        }
+
+        /**
+         * This method substitute an old {@link OperationItem} object with a new one, if not already present.
+         * 
+         * @param changedOp
+         */
+        private void substituteDescriptors(OperationItem changedOp) {
+            // Selection of the old OperationItem
+            OperationItem operationItem = map.get(changedOp.getName());
+            // Check if the item is present
+            boolean present = operationItem != null
+                    && !operationItem.getVendor().equalsIgnoreCase(changedOp.getVendor());
+            // Selection of the new factory
+            Object factory = changedOp.getCurrentFactory();
+            // If the OperationItem is already present, then it is unregistered and the new item is registered.
+            if (present) {
+                // Unregistering Descriptor and Factory
+                Object currentFactory = operationItem.getCurrentFactory();
+                boolean registerFactory = factory == null
+                        || !currentFactory.getClass().isAssignableFrom(factory.getClass());
+                if (currentFactory != null && registerFactory) {
+                    registry.unregisterFactory(RenderedRegistryMode.MODE_NAME, operationItem
+                            .getDescriptor().getName(), operationItem.getVendor(), currentFactory);
+                }
+                registry.unregisterDescriptor(operationItem.getDescriptor());
+                // registering descriptor
+                registry.registerDescriptor(changedOp.getDescriptor());
+                // registering factory
+                if (factory != null) {
+                    registry.registerFactory(RenderedRegistryMode.MODE_NAME, changedOp
+                            .getDescriptor().getName(), changedOp.getVendor(), changedOp
+                            .getCurrentFactory());
+                }
+            } else {
+                // If the operationItem is null then it is registered
+                if (operationItem == null) {
+                    // registering descriptor
+                    registry.registerDescriptor(changedOp.getDescriptor());
+                    // registering factory
+                    if (changedOp.getCurrentFactory() != null) {
+                        registry.registerFactory(RenderedRegistryMode.MODE_NAME, changedOp
+                                .getDescriptor().getName(), changedOp.getVendor(), changedOp
+                                .getCurrentFactory());
+                    }
+                }
+            }
+        }
+
+        /**
+         * This method add a new {@link OperationItem} inside the map, replacing an old one if present.
+         * 
+         * @param changedOp
+         */
+        public void substituteSingleOp(OperationItem changedOp) {
+            map.put(changedOp.getName(), changedOp);
+        }
+
+        /**
+         * This method substitute the factory associated to the operation
+         * 
+         * @param factory
+         * @param descriptorName
+         * @param vendor
+         */
+        public void substituteFactory(Object factory, String descriptorName, String vendor) {
+            OperationItem item = map.get(descriptorName);
+
+            // Check if the Operation descriptor is present
+            boolean present = item != null && item.getVendor().equalsIgnoreCase(vendor);
+            // If present, the factory is set.
+            if (present) {
+                if (factory.getClass().getName().contains("Mlib")) {
+                    item.setMlibFactory(factory);
+                    item.setMlibPreference(true);
+                } else {
+                    item.setFactory(factory);
+                    item.setMlibPreference(false);
+                }
+            } else {
+                // Create a new Item and set it in the map
+                RegistryElementDescriptor desc = registry.getDescriptor(
+                        RenderedRegistryMode.MODE_NAME, descriptorName);
+                // The new item is added
+                if (desc != null && desc instanceof OperationDescriptor) {
+                    try {
+                        OperationItem itemNew = new OperationItem((OperationDescriptor) desc);
+                        if (factory.getClass().getName().contains("Mlib")) {
+                            item.setMlibFactory(factory);
+                            item.setMlibPreference(true);
+                        } else {
+                            item.setFactory(factory);
+                            item.setMlibPreference(false);
+                        }
+                        map.put(descriptorName, itemNew);
+                    } catch (IllegalArgumentException e) {
+                        throw new IllegalArgumentException(
+                                "Unable to register the Factory for the following descriptor: "
+                                        + descriptorName, e);
+                    }
+                } else {
+                    throw new IllegalArgumentException(
+                            "Unable to register the Factory for the following descriptor: "
+                                    + descriptorName);
+                }
+            }
+        }
+
+        /**
+         * Removes an {@link OperationItem} from the inner map
+         * 
+         * @param operationItem
+         */
+        public void removeSingleOp(OperationItem operationItem) {
+            map.remove(operationItem.getName());
+        }
+
+        /**
+         * Removes the factory from the map.
+         * 
+         * @param factory
+         * @param descriptorName
+         * @param productName
+         */
+        public void removeFactory(Object factory, String descriptorName, String productName) {
+            OperationItem item = map.get(descriptorName);
+
+            // Check if the Operation descriptor is present
+            boolean present = item != null && item.getVendor().equalsIgnoreCase(productName);
+
+            if (present) {
+                item.setFactory(null);
+                item.setMlibFactory(null);
+                item.setMlibPreference(false);
+            } else {
+                // Create a new Item and set it in the map without defining the factory
+                RegistryElementDescriptor desc = registry.getDescriptor(
+                        RenderedRegistryMode.MODE_NAME, descriptorName);
+
+                if (desc != null && desc instanceof OperationDescriptor) {
+                    OperationItem itemNew = new OperationItem((OperationDescriptor) desc);
+                    map.put(descriptorName, itemNew);
+                } else {
+                    throw new IllegalArgumentException(
+                            "Unable to unregister the Factory for the following descriptor: "
+                                    + descriptorName);
+                }
+            }
+        }
+    }
+}

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/JAIExt.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/JAIExt.java
@@ -1,0 +1,303 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2014 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.geosolutions.jaiext;
+
+import it.geosolutions.jaiext.ConcurrentOperationRegistry.OperationCollection;
+import it.geosolutions.jaiext.ConcurrentOperationRegistry.OperationItem;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.media.jai.OperationDescriptor;
+import javax.media.jai.OperationRegistry;
+import javax.media.jai.registry.RenderedRegistryMode;
+
+/**
+ * Utility class used for registering and unregistering JAI and JAI-EXT operations.
+ * 
+ * @author Nicola Lagomarsini - GeoSolutions
+ * 
+ */
+public class JAIExt {
+
+    /** The reader/writer lock for this class. */
+    private ReadWriteLock lock;
+
+    /** The default instance of the {@link JAIExt} class */
+    private static JAIExt jaiext;
+
+    /** {@link OperationRegistry} used by the {@link JAIExt} class */
+    private ConcurrentOperationRegistry registry;
+
+    /** {@link Logger} used for Logging any excpetion or warning */
+    private static final Logger LOGGER = Logger.getLogger(JAIExt.class.toString());
+
+    /** Initialization of the {@link JAIExt} instance */
+    public static void initJAIEXT(ConcurrentOperationRegistry registry) {
+        if (jaiext == null) {
+            jaiext = new JAIExt(registry);
+        }
+    }
+
+    /**
+     * This method unregister a JAI operation and register the related JAI-EXT one
+     * 
+     * @param descriptorName
+     */
+    public static void registerJAIEXTDescriptor(String descriptorName) {
+        jaiext.registerOp(descriptorName, true);
+    }
+
+    /**
+     * This method unregister a JAI-EXT operation and register the related JAI one
+     * 
+     * @param descriptorName
+     */
+    public static void registerJAIDescriptor(String descriptorName) {
+        jaiext.registerOp(descriptorName, false);
+    }
+
+    /**
+     * This method sets/unsets the netive acceleration for a JAI operation
+     * 
+     * @param descriptorName
+     * @param accelerated
+     */
+    public static void setJAIAcceleration(String descriptorName, boolean accelerated) {
+        jaiext.setAcceleration(descriptorName, accelerated);
+    }
+
+    /**
+     * Gets a List of all the operations currently registered.
+     * 
+     * @return
+     */
+    public static List<OperationItem> getOperations() {
+        return jaiext.getItems();
+    }
+
+    /**
+     * Get a List of the available JAI-EXT operations
+     * 
+     * @return
+     */
+    public static List<OperationItem> getJAIEXTOperations() {
+        return jaiext.getJAIEXTAvailableOps();
+    }
+
+    /**
+     * Returns the current {@link ConcurrentOperationRegistry} used.
+     * 
+     * @return
+     */
+    public static ConcurrentOperationRegistry getRegistry() {
+        return jaiext.registry;
+    }
+
+    private JAIExt(ConcurrentOperationRegistry registry) {
+        this.registry = registry;
+        this.lock = new ReentrantReadWriteLock();
+    }
+
+    /**
+     * Registers the operation defined by the descriptor name. The boolean indicates if the initial operation was a JAI or a JAI-EXT one.
+     * 
+     * @param descriptorName
+     * @param fromJAI
+     */
+    private void registerOp(String descriptorName, boolean fromJAI) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            // Selection of the input vendor name
+            String vendor = fromJAI ? (descriptorName.equalsIgnoreCase("Null") ? ConcurrentOperationRegistry.JAI_PRODUCT_NULL
+                    : ConcurrentOperationRegistry.JAI_PRODUCT)
+                    : ConcurrentOperationRegistry.JAIEXT_PRODUCT;
+            // Check if the old descriptor is present
+            OperationDescriptor op = (OperationDescriptor) registry.getDescriptor(
+                    RenderedRegistryMode.MODE_NAME, descriptorName);
+
+            boolean registered = false;
+
+            String inVendor = fromJAI ? "JAI" : "JAI-EXT";
+            String outVendor = fromJAI ? "JAI-EXT" : "JAI";
+            // Ensure that the descriptor has the same vendor from that indicated by the vendor, string.
+            // Otherwise it is already registered or it is not a JAI/JAI-EXT operation.
+            if (op != null
+                    && op.getResourceBundle(null)
+                            .getString(ConcurrentOperationRegistry.VENDOR_NAME)
+                            .equalsIgnoreCase(vendor)) {
+
+                // Selection of the OperationItem associated to the old descriptor
+                OperationCollection collection = registry.getOperationCollection();
+                OperationItem oldItem = collection.get(descriptorName);
+
+                // Getting the JAI/JAI-EXT associated OperationItem
+                OperationItem newItem = registry.getOperationMap(!fromJAI).get(descriptorName);
+                // Unregistering of the old operation and registering of the new one
+                if (newItem != null) {
+                    if (oldItem.getCurrentFactory() != null) {
+                        registry.unregisterFactory(RenderedRegistryMode.MODE_NAME, descriptorName,
+                                vendor, oldItem.getCurrentFactory());
+                        if (LOGGER.isLoggable(Level.FINEST)) {
+                            LOGGER.log(Level.FINEST, "Unregistered Factory for the operation: "
+                                    + descriptorName);
+                        }
+                    }
+                    registry.unregisterDescriptor(op);
+
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.log(Level.FINEST, "Unregistered " + inVendor
+                                + " descriptor for the operation: " + descriptorName);
+                    }
+                    registry.registerDescriptor(newItem.getDescriptor());
+
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.log(Level.FINEST, "Registered " + outVendor
+                                + " descriptor for the operation: " + descriptorName);
+                    }
+
+                    if (newItem.getCurrentFactory() != null) {
+                        registry.registerFactory(RenderedRegistryMode.MODE_NAME, descriptorName,
+                                newItem.getVendor(), newItem.getCurrentFactory());
+                        if (LOGGER.isLoggable(Level.FINEST)) {
+                            LOGGER.log(Level.FINEST, "Registered Factory for the operation: "
+                                    + descriptorName);
+                        }
+                    }
+                    registered = true;
+                }
+            }
+            // Log the operation
+            if (!registered) {
+                if (LOGGER.isLoggable(Level.INFO)) {
+                    LOGGER.log(Level.INFO, "Unable to register the descriptor related "
+                            + "to the following operation: " + descriptorName);
+                }
+            } else {
+                if (LOGGER.isLoggable(Level.INFO)) {
+                    LOGGER.log(Level.INFO, "Registered operation: " + descriptorName);
+                }
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * This method sets or unsets the acceleration for the input operation if it is a JAI one.
+     * 
+     * @param descriptorName
+     * @param accelerated
+     */
+    private void setAcceleration(String descriptorName, boolean accelerated) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            // Selection of the OperationItem associated to the descriptor
+            OperationCollection collection = registry.getOperationCollection();
+            OperationItem item = collection.get(descriptorName);
+            // Selection of the old JAI OperationItem.
+            OperationItem jaiItem = registry.getOperationMap(true).get(descriptorName);
+            if (item.getVendor().equalsIgnoreCase(ConcurrentOperationRegistry.JAI_PRODUCT)
+                    && jaiItem.getFactory() != null && jaiItem.getMlibFactory() != null) {
+                // Definition of the old and the new factories
+                Object oldFactory = null;
+                Object newFactory = null;
+                // Acceleration String
+                String acc1 = null;
+                String acc2 = null;
+                // Setting/ Unsetting of the acceleration
+                if (accelerated) {
+                    oldFactory = jaiItem.getFactory();
+                    newFactory = jaiItem.getMlibFactory();
+                    acc1 = " Accelerated";
+                    acc2 = "";
+                } else {
+                    newFactory = jaiItem.getFactory();
+                    oldFactory = jaiItem.getMlibFactory();
+                    acc1 = "";
+                    acc2 = " Accelerated";
+                }
+                // Registration step
+                registry.unregisterFactory(RenderedRegistryMode.MODE_NAME, descriptorName,
+                        ConcurrentOperationRegistry.JAI_PRODUCT, oldFactory);
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "Unregistered" + acc1 + " Factory for the operation: "
+                            + descriptorName);
+                }
+                registry.registerFactory(RenderedRegistryMode.MODE_NAME, descriptorName,
+                        ConcurrentOperationRegistry.JAI_PRODUCT, newFactory);
+                
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "Registered" + acc2 + " Factory for the operation: "
+                            + descriptorName);
+                }
+            }else{
+                if (LOGGER.isLoggable(Level.INFO)) {
+                    LOGGER.log(Level.INFO, "Unable to set acceleration for following operation: " + descriptorName);
+                }
+            }
+        } finally {
+            writeLock.unlock();
+        }
+
+    }
+
+    /**
+     * Returns a List of the operations currently registered
+     * 
+     * @return
+     */
+    private List<OperationItem> getItems() {
+        Collection<OperationItem> items = registry.getOperations();
+        List<OperationItem> ops = new ArrayList<OperationItem>(items.size());
+        for (OperationItem item : items) {
+            ops.add(item);
+        }
+        return ops;
+    }
+
+    /**
+     * Returns a List of the operations currently registered which are present in the JAI-EXT API:
+     * 
+     * @return
+     */
+    private List<OperationItem> getJAIEXTAvailableOps() {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            OperationCollection items = registry.getOperationCollection();
+            Set<String> jaiextKeys = registry.getOperationMap(false).keySet();
+            List<OperationItem> ops = new ArrayList<OperationItem>(jaiextKeys.size());
+            for (String key : jaiextKeys) {
+                ops.add(items.get(key));
+            }
+            return ops;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/RegistryFileParser.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/RegistryFileParser.java
@@ -1,0 +1,261 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2014 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.geosolutions.jaiext;
+
+import it.geosolutions.jaiext.ConcurrentOperationRegistry.OperationItem;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StreamTokenizer;
+import java.net.URL;
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.media.jai.OperationDescriptor;
+import javax.media.jai.RegistryElementDescriptor;
+import javax.media.jai.RegistryMode;
+import javax.media.jai.registry.RenderedRegistryMode;
+
+/**
+ * A class to parse the JAI registry file.
+ * 
+ * @author Nicola Lagomarsini - GeoSolutions
+ */
+class RegistryFileParser {
+
+    /** {@link Logger} used for Logging any exception or warning */
+    private static final Logger LOGGER = Logger.getLogger(RegistryFileParser.class.toString());
+
+    /**
+     * Returns a map with the descriptors, factories from the <code>URL</code>.
+     */
+    static Map<String, OperationItem> parseFile(ClassLoader cl, URL url) throws IOException {
+
+        return (new RegistryFileParser(cl, url)).parseFile();
+    }
+
+    /** Input {@link URL} for the registryFile */
+    private URL url;
+
+    /** Input stream for the registryFile */
+    private InputStream is;
+
+    /** {@link ClassLoader} used for loading the registryFile resources */
+    private ClassLoader classLoader;
+
+    private BufferedReader reader;
+
+    /**
+     * Create a {@link RegistryFileParser} from an <code>URL</code>
+     */
+    private RegistryFileParser(ClassLoader cl, URL url) throws IOException {
+
+        this.is = url.openStream();
+        this.url = null;
+        this.classLoader = cl;
+
+        // Set up streamtokenizer
+        reader = new BufferedReader(new InputStreamReader(is));
+    }
+
+    // Aliases for backward compatibility
+    private static String[][] aliases = { { "odesc", "descriptor" }, { "rif", "rendered" },
+            { "crif", "renderable" }, { "cif", "collection" }, };
+
+    /**
+     * Map old keywords to the new keywords
+     */
+    private String mapName(String key) {
+        for (int i = 0; i < aliases.length; i++)
+            if (key.equalsIgnoreCase(aliases[i][0]))
+                return aliases[i][1];
+
+        return key;
+    }
+
+    /**
+     * Create an instance given the class name.
+     */
+    private Object getInstance(String className) {
+
+        try {
+            Class descriptorClass = null;
+            String errorMsg = null;
+
+            // Since the classes listed in the registryFile can
+            // reside anywhere (core, ext, classpath or the specified
+            // classloader) we have to try every place.
+
+            // First try the specified classloader
+            if (classLoader != null) {
+                try {
+                    descriptorClass = Class.forName(className, true, classLoader);
+                } catch (Exception e) {
+                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                    errorMsg = e.getMessage();
+                }
+            }
+
+            // Next try the callee classloader
+            if (descriptorClass == null) {
+                try {
+                    descriptorClass = Class.forName(className);
+                } catch (Exception e) {
+                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                    errorMsg = e.getMessage();
+                }
+            }
+
+            // Then try the System classloader (because the specified
+            // classloader might be null and the callee classloader
+            // might be an ancestor of the SystemClassLoader
+            if (descriptorClass == null) {
+                try {
+                    descriptorClass = Class.forName(className, true,
+                            ClassLoader.getSystemClassLoader());
+                } catch (Exception e) {
+                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                    errorMsg = e.getMessage();
+                }
+            }
+            // If nothing is found an exception is reported
+            if (descriptorClass == null) {
+                registryFileError(errorMsg);
+                return null;
+            }
+
+            return descriptorClass.newInstance();
+
+        } catch (Exception e) {
+            registryFileError(e.getMessage());
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse the entire registry file and stores its informations inside a map.
+     */
+    Map<String, OperationItem> parseFile() throws IOException {
+        // Initialization of the map
+        Map<String, OperationItem> operations = new HashMap<String, OperationItem>();
+
+        String[] keys;
+
+        while ((keys = getNextLine()) != null) {
+
+            RegistryMode mode;
+            // Mapping of the key
+            String key = mapName(keys[0]);
+
+            // Selection of the descriptor
+            if (key.equalsIgnoreCase("descriptor")) {
+                RegistryElementDescriptor red = (RegistryElementDescriptor) getInstance(keys[1]);
+                // Storing the information of the description only if it is an OperationDescriptor
+                if (red != null && red instanceof OperationDescriptor) {
+                    OperationDescriptor desc = (OperationDescriptor) red;
+                    operations.put(desc.getName(), new OperationItem(desc));
+                }
+
+                // If it is a rendered registry mode, then get the
+                // factory object.
+            } else if ((mode = RegistryMode.getMode(key)) != null) {
+                Object factory = getInstance(keys[1]);
+                if (mode.getName().equalsIgnoreCase(RenderedRegistryMode.MODE_NAME)
+                        && factory != null) {
+                    operations.get(keys[3]).setFactory(factory);
+                }
+
+            } else if (!(key.equalsIgnoreCase("registryMode") || key.equalsIgnoreCase("pref") || key
+                    .equalsIgnoreCase("productPref"))) {
+                registryFileError("Can not parse line");
+            }
+        }
+
+        // If this was read in from an URL, we created the InputStream
+        // and so we should close it.
+        reader.close();
+        is.close();
+
+        return operations;
+    }
+
+    private String[] getNextLine() throws IOException {
+        // TODO Auto-generated method stub
+        String line = reader.readLine();
+        if (line != null) {
+            if (line.isEmpty() || line.startsWith("#") || line.startsWith("\\s")) {
+                return getNextLine();
+            } else {
+                String[] split = line.split("\\s");
+                String[] corrected = new String[split.length];
+                int count = 0;
+                for (int i = 0; i < split.length; i++) {
+                    if (!(split[i].equals("\\s") || split[i].isEmpty())) {
+                        corrected[count] = split[i];
+                        count++;
+                    }
+                }
+                return corrected;
+            }
+        } else {
+            return null;
+        }
+
+    }
+
+    /** Boolean indicating that the header line has already been printed */
+    private boolean headerLinePrinted = false;
+
+    /**
+     * Print the line number and then print the passed in message.
+     */
+    private void registryFileError(String msg) {
+
+        if (!headerLinePrinted) {
+
+            if (url != null) {
+                errorMsg("Error while parsing JAI registry file " + url.getPath(), null);
+            }
+
+            headerLinePrinted = true;
+        }
+
+        if (msg != null)
+            errorMsg(msg, null);
+    }
+
+    /**
+     * Creates a <code>MessageFormat</code> object and set the <code>Locale</code> to default and formats the message
+     */
+    private void errorMsg(String key, Object[] args) {
+        MessageFormat mf = new MessageFormat(key);
+        mf.setLocale(Locale.getDefault());
+
+        LOGGER.log(Level.SEVERE, mf.format(args));
+    }
+
+}

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/interpolators/InterpolationBicubic.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/interpolators/InterpolationBicubic.java
@@ -64,6 +64,8 @@ public class InterpolationBicubic extends InterpolationTable implements Interpol
     
     /** Boolean used for indicating that the No Data Range is not degenarated(useful only for NaN check inside Float or Double Range) */
     private boolean isNotPointRange;
+
+    private boolean isBicubic2;
     
     /**
      * Simple interpolator object used for Bicubic/Bicubic2 interpolation. On construction it is possible to set a range for no data values that will
@@ -87,6 +89,7 @@ public class InterpolationBicubic extends InterpolationTable implements Interpol
         if (precisionBits > 0) {
             round = 1 << (precisionBits - 1);
         }
+        this.isBicubic2 = !bicubic2Disabled;
     }
 
     
@@ -114,6 +117,10 @@ public class InterpolationBicubic extends InterpolationTable implements Interpol
             this.noDataRange = noDataRange;     
             this.isNotPointRange = !noDataRange.isPoint();
         }
+    }
+    
+    public boolean isBicubic2(){
+        return isBicubic2;
     }
     
     public int getDataType() {

--- a/jt-utilities/src/test/java/it/geosolutions/jaiext/DummyScaleCRIF.java
+++ b/jt-utilities/src/test/java/it/geosolutions/jaiext/DummyScaleCRIF.java
@@ -1,0 +1,59 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2014 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.geosolutions.jaiext;
+
+import java.awt.RenderingHints;
+import java.awt.image.RenderedImage;
+import java.awt.image.renderable.ContextualRenderedImageFactory;
+import java.awt.image.renderable.ParameterBlock;
+
+import javax.media.jai.CRIFImpl;
+import javax.media.jai.ImageLayout;
+import javax.media.jai.NullOpImage;
+import javax.media.jai.OpImage;
+
+import com.sun.media.jai.opimage.RIFUtil;
+
+/**
+ * Dummy {@link ContextualRenderedImageFactory} for the "Scale" operation. Internally it calls the "Null" operation.
+ * 
+ * @author Nicola Lagomarsini - GeoSolutions
+ * 
+ */
+public class DummyScaleCRIF extends CRIFImpl {
+
+    /** Constructor. */
+    public DummyScaleCRIF() {
+        super("scale");
+    }
+
+    /**
+     * Creates a new Image in the rendered layer. This method satisfies the implementation of RIF.
+     * 
+     * @param paramBlock The source image.
+     */
+    public RenderedImage create(ParameterBlock paramBlock, RenderingHints renderHints) {
+
+        // Get ImageLayout from renderHints if any.
+        ImageLayout layout = RIFUtil.getImageLayoutHint(renderHints);
+        // Get the source
+        RenderedImage source = paramBlock.getRenderedSource(0);
+        // returns a new Image
+        return new NullOpImage(source, layout, renderHints, OpImage.OP_COMPUTE_BOUND);
+    }
+}

--- a/jt-utilities/src/test/java/it/geosolutions/jaiext/DummyScaleDescriptor.java
+++ b/jt-utilities/src/test/java/it/geosolutions/jaiext/DummyScaleDescriptor.java
@@ -1,0 +1,85 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2014 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.geosolutions.jaiext;
+
+import java.awt.RenderingHints;
+import java.awt.image.RenderedImage;
+import java.awt.image.renderable.ParameterBlock;
+
+import javax.media.jai.JAI;
+import javax.media.jai.OperationDescriptorImpl;
+import javax.media.jai.ParameterBlockJAI;
+import javax.media.jai.RenderedOp;
+import javax.media.jai.registry.RenderedRegistryMode;
+
+/**
+ * Dummy {@link OperationDescriptor} for the Scale operation used for testing the {@link JAIExt} and {@link ConcurrentOperationRegistry} classes.
+ * 
+ * @author Nicola Lagomarsini - GeoSolutions
+ * 
+ */
+public class DummyScaleDescriptor extends OperationDescriptorImpl {
+
+    /**
+     * The resource strings that provide the general documentation and specify the parameter list for this operation.
+     */
+    private static final String[][] resources = { { "GlobalName", "Scale" },
+            { "LocalName", "Scale" }, { "Vendor", "it.geosolutions.jaiext" },
+            { "Description", "null" }, { "DocURL", "null" }, { "Version", "0.0" }
+
+    };
+
+    /**
+     * Modes supported by the operation
+     */
+    private static final String[] supportedModes = { "rendered" };
+
+    /** Constructor. */
+    public DummyScaleDescriptor() {
+        super(resources, supportedModes, 1, null, null, null, null);
+    }
+
+    /** Returns <code>false</code> since renderable operation is supported but never tested. */
+    public boolean isRenderableSupported() {
+        return false;
+    }
+
+    /**
+     * Resizes an image.
+     * 
+     * <p>
+     * Creates a <code>ParameterBlockJAI</code> from all supplied arguments except <code>hints</code> and invokes
+     * {@link JAI#create(String,ParameterBlock,RenderingHints)}.
+     * 
+     * @see JAI
+     * @see ParameterBlockJAI
+     * @see RenderedOp
+     * 
+     * @param source0 <code>RenderedImage</code> source 0.
+     * @param hints The <code>RenderingHints</code> to use. May be <code>null</code>.
+     * @return The <code>RenderedOp</code> destination.
+     * @throws IllegalArgumentException if <code>source0</code> is <code>null</code>.
+     */
+    public static RenderedOp create(RenderedImage source0, RenderingHints hints) {
+        ParameterBlockJAI pb = new ParameterBlockJAI("Scale", RenderedRegistryMode.MODE_NAME);
+        // Setting of the source
+        pb.setSource("source0", source0);
+        // Execution of the operation.
+        return JAI.create("Scale", pb, hints);
+    }
+}

--- a/jt-utilities/src/test/java/it/geosolutions/jaiext/JAIEXTTest.java
+++ b/jt-utilities/src/test/java/it/geosolutions/jaiext/JAIEXTTest.java
@@ -1,0 +1,200 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2014 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.geosolutions.jaiext;
+
+import static org.junit.Assert.assertTrue;
+import it.geosolutions.jaiext.ConcurrentOperationRegistry.OperationCollection;
+import it.geosolutions.jaiext.ConcurrentOperationRegistry.OperationItem;
+import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
+import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
+import it.geosolutions.jaiext.interpolators.InterpolationNearest;
+import it.geosolutions.jaiext.testclasses.TestData;
+
+import java.awt.image.renderable.ParameterBlock;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import javax.media.jai.JAI;
+import javax.media.jai.operator.ScaleDescriptor;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.media.jai.mlib.MlibScaleRIF;
+import com.sun.media.jai.opimage.ScaleCRIF;
+
+public class JAIEXTTest {
+
+    private final static String SCALE = "Scale";
+
+    private static File newJAIFile;
+
+    @BeforeClass
+    public static void setup() throws FileNotFoundException, IOException {
+        final File inputJAIFile = TestData.file(JAIEXTTest.class, "META-INF" + File.separator
+                + "registryFile2.jai");
+        newJAIFile = new File(inputJAIFile.getParentFile().getParentFile().getParentFile()
+                .getParentFile().getParentFile().getParentFile(), "META-INF" + File.separator
+                + "registryFile.jai");
+        FileUtils.copyFile(inputJAIFile, newJAIFile);
+
+        // Setting of the operation registry
+        ConcurrentOperationRegistry registry = (ConcurrentOperationRegistry) ConcurrentOperationRegistry
+                .initializeRegistry();
+        JAI.getDefaultInstance().setOperationRegistry(registry);
+        JAIExt.initJAIEXT(registry);
+    }
+
+    @Test
+    public void testJAIEXT() {
+        // Getting the registry
+        ConcurrentOperationRegistry registry = JAIExt.getRegistry();
+        // Ensure that the "Scale" operation is described by the dummy descriptor
+        OperationCollection operations = registry.getOperationCollection();
+        OperationItem operationItem = operations.get(SCALE);
+        // First check that the scale operation is present
+        assertTrue(operationItem != null);
+        // Using JAI-EXT for changing the descriptor from JAI to JAI-EXT
+        JAIExt.registerJAIEXTDescriptor(SCALE);
+        // Ensure that the "Scale" operation is described by the dummy descriptor
+        operations = registry.getOperationCollection();
+        operationItem = operations.get(SCALE);
+        // Then check that the descriptor is an instance of the DummyScaleDescriptor class
+        assertTrue(operationItem.getDescriptor().getClass()
+                .isAssignableFrom(DummyScaleDescriptor.class));
+        // Also check that the associated RIF is an instance of the DummyScaleCRIF class
+        assertTrue(operationItem.getCurrentFactory().getClass()
+                .isAssignableFrom(DummyScaleCRIF.class));
+
+        // Using JAI-EXT for changing the descriptor from JAI-EXT to JAI
+        JAIExt.registerJAIDescriptor(SCALE);
+        // Then check that the descriptor is an instance of the ScaleDescriptor class
+        operations = registry.getOperationCollection();
+        operationItem = operations.get(SCALE);
+        assertTrue(operationItem.getDescriptor().getClass().isAssignableFrom(ScaleDescriptor.class));
+        // Also check that the associated RIF is an instance of the ScaleCRIF class
+        assertTrue(operationItem.getCurrentFactory().getClass().isAssignableFrom(ScaleCRIF.class));
+
+        // Using JAI-EXT class for setting the MediaLib Factory
+        // Setting the JAI operation
+        JAIExt.registerJAIDescriptor(SCALE);
+        // Set the acceleration
+        JAIExt.setJAIAcceleration(SCALE, true);
+        // Then check that the descriptor is an instance of the ScaleDescriptor class
+        operations = registry.getOperationCollection();
+        operationItem = operations.get(SCALE);
+        // Also check that the associated RIF is an instance of the ScaleCRIF class
+        assertTrue(operationItem.getCurrentFactory().getClass()
+                .isAssignableFrom(MlibScaleRIF.class));
+
+        // Unset the acceleration
+        JAIExt.setJAIAcceleration(SCALE, false);
+        // Then check that the descriptor is an instance of the ScaleDescriptor class
+        operations = registry.getOperationCollection();
+        operationItem = operations.get(SCALE);
+        // Also check that the associated RIF is an instance of the ScaleCRIF class
+        assertTrue(operationItem.getCurrentFactory().getClass().isAssignableFrom(ScaleCRIF.class));
+    }
+
+    @Test
+    public void testInterpolation() {
+        // Getting the registry
+        ConcurrentOperationRegistry registry = JAIExt.getRegistry();
+        // Using JAI-EXT for changing the descriptor from JAI-EXT to JAI
+        JAIExt.registerJAIDescriptor(SCALE);
+        
+        // NEAREST INTERPOLATION
+        
+        // Trying to execute the Scale operation by passing JAI-EXT interpolation objects
+        // and checking if the registry is able to convert them to JAI interpolation objects
+        Object[] args = new Object[1];
+        ParameterBlock block = new ParameterBlock();
+        // Setting of a JAIEXT interpolation object
+        block.set(new InterpolationNearest(null, false, 0, 0), 0);
+        // Setting of the parameterblock
+        args[0] = block;
+        registry.checkInterpolation(SCALE, args);
+        
+        // Ensure that the modified parameterblock contains a JAI interpolation object
+        Object interp = block.getObjectParameter(0);
+        assertTrue(interp.getClass().isAssignableFrom(javax.media.jai.InterpolationNearest.class));
+        
+        // BILINEAR INTERPOLATION
+        
+        // Trying to execute the Scale operation by passing JAI-EXT interpolation objects
+        // and checking if the registry is able to convert them to JAI interpolation objects
+        args = new Object[1];
+        block = new ParameterBlock();
+        // Setting of a JAIEXT interpolation object
+        int subsampleBits = 8;
+        block.set(new InterpolationBilinear(subsampleBits, null, false, 0, 0), 0);
+        // Setting of the parameterblock
+        args[0] = block;
+        registry.checkInterpolation(SCALE, args);
+        
+        // Ensure that the modified parameterblock contains a JAI interpolation object
+        interp = block.getObjectParameter(0);
+        assertTrue(interp.getClass().isAssignableFrom(javax.media.jai.InterpolationBilinear.class));
+        assertTrue(((javax.media.jai.InterpolationBilinear)interp).getSubsampleBitsH() == subsampleBits);
+        
+        // BICUBIC INTERPOLATION
+        
+        // Trying to execute the Scale operation by passing JAI-EXT interpolation objects
+        // and checking if the registry is able to convert them to JAI interpolation objects
+        args = new Object[1];
+        block = new ParameterBlock();
+        // Setting of a JAIEXT interpolation object
+        block.set(new InterpolationBicubic(subsampleBits, null, false, 0, 0, true, subsampleBits), 0);
+        // Setting of the parameterblock
+        args[0] = block;
+        registry.checkInterpolation(SCALE, args);
+        
+        // Ensure that the modified parameterblock contains a JAI interpolation object
+        interp = block.getObjectParameter(0);
+        assertTrue(interp.getClass().isAssignableFrom(javax.media.jai.InterpolationBicubic.class));
+        assertTrue(((javax.media.jai.InterpolationBicubic)interp).getSubsampleBitsH() == subsampleBits);
+        assertTrue(((javax.media.jai.InterpolationBicubic)interp).getPrecisionBits() == subsampleBits);
+        
+        // BICUBIC 2 INTERPOLATION
+        
+        // Trying to execute the Scale operation by passing JAI-EXT interpolation objects
+        // and checking if the registry is able to convert them to JAI interpolation objects
+        args = new Object[1];
+        block = new ParameterBlock();
+        // Setting of a JAIEXT interpolation object
+        block.set(new InterpolationBicubic(subsampleBits, null, false, 0, 0, false, subsampleBits), 0);
+        // Setting of the parameterblock
+        args[0] = block;
+        registry.checkInterpolation(SCALE, args);
+        
+        // Ensure that the modified parameterblock contains a JAI interpolation object
+        interp = block.getObjectParameter(0);
+        assertTrue(interp.getClass().isAssignableFrom(javax.media.jai.InterpolationBicubic2.class));
+        assertTrue(((javax.media.jai.InterpolationBicubic2)interp).getSubsampleBitsH() == subsampleBits);
+        assertTrue(((javax.media.jai.InterpolationBicubic2)interp).getPrecisionBits() == subsampleBits);
+    }
+
+    @AfterClass
+    public static void fileDisposal() {
+        FileUtils.deleteQuietly(newJAIFile);
+        FileUtils.deleteQuietly(newJAIFile.getParentFile());
+    }
+}

--- a/jt-utilities/src/test/resources/it/geosolutions/jaiext/test-data/META-INF/registryFile2.jai
+++ b/jt-utilities/src/test/resources/it/geosolutions/jaiext/test-data/META-INF/registryFile2.jai
@@ -1,0 +1,11 @@
+#
+# Image descriptors
+#
+
+descriptor  it.geosolutions.jaiext.DummyScaleDescriptor
+
+#
+# RenderedImageFactories
+#
+
+rendered  it.geosolutions.jaiext.DummyScaleCRIF  it.geosolutions.jaiext  Scale Scale

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <jt.version>1.2.0</jt.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.8.1</junit.version>
+	<apache.version>2.1</apache.version>
      <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
     <guava.version>17.0</guava.version>


### PR DESCRIPTION
This pull request fixes issue https://github.com/geosolutions-it/jai-ext/issues/31 and adds a new JAIEXT class for registering and unregistering JAI and JAI-EXT operations.
