### PR TITLE
Make sure nodata get converted to the target type before using them

### DIFF
--- a/jt-affine/src/main/java/it/geosolutions/jaiext/affine/AffineCRIF.java
+++ b/jt-affine/src/main/java/it/geosolutions/jaiext/affine/AffineCRIF.java
@@ -17,17 +17,6 @@
  */
 package it.geosolutions.jaiext.affine;
 
-import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
-import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
-import it.geosolutions.jaiext.interpolators.InterpolationNearest;
-import it.geosolutions.jaiext.range.Range;
-import it.geosolutions.jaiext.scale.ScaleBicubicOpImage;
-import it.geosolutions.jaiext.scale.ScaleBilinearOpImage;
-import it.geosolutions.jaiext.scale.ScaleGeneralOpImage;
-import it.geosolutions.jaiext.scale.ScaleNearestOpImage;
-import it.geosolutions.jaiext.translate.TranslateIntOpImage;
-import it.geosolutions.jaiext.utilities.ImageUtilities;
-
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
@@ -51,6 +40,18 @@ import javax.media.jai.ROI;
 import com.sun.media.jai.mlib.MlibAffineRIF;
 import com.sun.media.jai.opimage.CopyOpImage;
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
+import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
+import it.geosolutions.jaiext.interpolators.InterpolationNearest;
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
+import it.geosolutions.jaiext.scale.ScaleBicubicOpImage;
+import it.geosolutions.jaiext.scale.ScaleBilinearOpImage;
+import it.geosolutions.jaiext.scale.ScaleGeneralOpImage;
+import it.geosolutions.jaiext.scale.ScaleNearestOpImage;
+import it.geosolutions.jaiext.translate.TranslateIntOpImage;
+import it.geosolutions.jaiext.utilities.ImageUtilities;
 
 /**
  * @since EA4
@@ -95,6 +96,7 @@ public class AffineCRIF extends CRIFImpl {
         
         // Get the Nodata Range
         Range nodata = (Range) paramBlock.getObjectParameter(6);
+        nodata = RangeFactory.convert(nodata, source.getSampleModel().getDataType());
 
         // Get the boolean useROIAccessor (by default set to false)
         boolean useROIAccessor = false;
@@ -337,10 +339,10 @@ public class AffineCRIF extends CRIFImpl {
         //
         if ((tr[0] > 0.0) && (tr[2] == 0.0) && (tr[1] == 0.0) && (tr[3] > 0.0)) {
             // Get the source dimensions
-            float x0 = (float) source.getMinX();
-            float y0 = (float) source.getMinY();
-            float w = (float) source.getWidth();
-            float h = (float) source.getHeight();
+            float x0 = source.getMinX();
+            float y0 = source.getMinY();
+            float w = source.getWidth();
+            float h = source.getHeight();
 
             // Forward map the source using x0, y0, w and h
             float d_x0 = x0 * (float) tr[0] + (float) tr[4];
@@ -356,10 +358,10 @@ public class AffineCRIF extends CRIFImpl {
         //
         // Get sx0,sy0 coordinates and width & height of the source
         //
-        float sx0 = (float) source.getMinX();
-        float sy0 = (float) source.getMinY();
-        float sw = (float) source.getWidth();
-        float sh = (float) source.getHeight();
+        float sx0 = source.getMinX();
+        float sy0 = source.getMinY();
+        float sw = source.getWidth();
+        float sh = source.getHeight();
 
         //
         // The 4 points (clockwise order) are

--- a/jt-binarize/src/main/java/it/geosolutions/jaiext/binarize/BinarizeCRIF.java
+++ b/jt-binarize/src/main/java/it/geosolutions/jaiext/binarize/BinarizeCRIF.java
@@ -17,8 +17,6 @@
  */
 package it.geosolutions.jaiext.binarize;
 
-import it.geosolutions.jaiext.range.Range;
-
 import java.awt.RenderingHints;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ContextualRenderedImageFactory;
@@ -29,6 +27,9 @@ import javax.media.jai.ImageLayout;
 import javax.media.jai.ROI;
 
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
 
 /**
  * {@link ContextualRenderedImageFactory} implementation used for creating a new {@link BinarizeOpImage} instance.
@@ -56,6 +57,7 @@ public class BinarizeCRIF extends CRIFImpl {
         double threshold = pb.getDoubleParameter(0);
         ROI roi = (ROI) pb.getObjectParameter(1);
         Range nodata = (Range) pb.getObjectParameter(2);
+        nodata = RangeFactory.convert(nodata, src.getSampleModel().getDataType());
 
         return new BinarizeOpImage(src, renderHints, layout, threshold, roi, nodata);
     }

--- a/jt-border/src/main/java/it/geosolutions/jaiext/border/BorderRIF.java
+++ b/jt-border/src/main/java/it/geosolutions/jaiext/border/BorderRIF.java
@@ -17,14 +17,18 @@
 */
 package it.geosolutions.jaiext.border;
 
-import it.geosolutions.jaiext.range.Range;
 import java.awt.RenderingHints;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
 import java.awt.image.renderable.RenderedImageFactory;
+
 import javax.media.jai.BorderExtender;
 import javax.media.jai.ImageLayout;
+
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
 
 /**
  * A <code>RIF</code> supporting the "border" operation.
@@ -54,6 +58,7 @@ public class BorderRIF implements RenderedImageFactory {
         int bottomPad = pb.getIntParameter(3);
         BorderExtender type = (BorderExtender) pb.getObjectParameter(4);
         Range noData = (Range) pb.getObjectParameter(5);
+        noData = RangeFactory.convert(noData, source.getSampleModel().getDataType());
         double destinationNoData = pb.getDoubleParameter(6);
         // Creation of the BorderOpImage instance
         return new BorderOpImage(source, renderHints, layout, leftPad, rightPad, topPad, bottomPad,

--- a/jt-crop/src/main/java/it/geosolutions/jaiext/crop/CropCRIF.java
+++ b/jt-crop/src/main/java/it/geosolutions/jaiext/crop/CropCRIF.java
@@ -17,9 +17,6 @@
 */
 package it.geosolutions.jaiext.crop;
 
-import it.geosolutions.jaiext.mosaic.MosaicOpImage;
-import it.geosolutions.jaiext.range.Range;
-
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.RenderingHints.Key;
@@ -39,6 +36,10 @@ import javax.media.jai.ROIShape;
 import javax.media.jai.operator.MosaicDescriptor;
 
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.mosaic.MosaicOpImage;
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
 
 /**
  * The image factory for the Crop operator.
@@ -68,6 +69,7 @@ public class CropCRIF implements RenderedImageFactory {
         float height = paramBlock.getFloatParameter(CropDescriptor.HEIGHT_ARG);
         ROI roi = (ROI) paramBlock.getObjectParameter(CropDescriptor.ROI_ARG);
         Range noData = (Range) paramBlock.getObjectParameter(CropDescriptor.NO_DATA_ARG);
+        noData = RangeFactory.convert(noData, image.getSampleModel().getDataType());
         double[] destNoData = (double[]) paramBlock.getObjectParameter(CropDescriptor.DEST_NO_DATA_ARG);
         
         // only leave tile cache and tile scheduler (we can't instantiate directly RenderingHints

--- a/jt-lookup/src/main/java/it/geosolutions/jaiext/lookup/LookupCRIF.java
+++ b/jt-lookup/src/main/java/it/geosolutions/jaiext/lookup/LookupCRIF.java
@@ -17,8 +17,6 @@
 */
 package it.geosolutions.jaiext.lookup;
 
-import it.geosolutions.jaiext.range.Range;
-
 import java.awt.RenderingHints;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
@@ -28,6 +26,9 @@ import javax.media.jai.ImageLayout;
 import javax.media.jai.ROI;
 
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
 
 /**
  * Simple class that provides the RenderedImage create operation by calling the LookupOpImage. The input parameters are: ParameterBlock,
@@ -53,6 +54,7 @@ public class LookupCRIF extends CRIFImpl {
         double destinationNoData = pb.getDoubleParameter(1);
         ROI roi = (ROI) pb.getObjectParameter(2);
         Range noData = (Range) pb.getObjectParameter(3);
+        noData = RangeFactory.convert(noData, source.getSampleModel().getDataType());
         boolean useRoiAccessor = (Boolean) pb.getObjectParameter(4);
         // Creation of the lookup image
         return new LookupOpImage(source, layout, renderHints, table, destinationNoData, roi,

--- a/jt-rescale/src/main/java/it/geosolutions/jaiext/rescale/RescaleCRIF.java
+++ b/jt-rescale/src/main/java/it/geosolutions/jaiext/rescale/RescaleCRIF.java
@@ -17,8 +17,6 @@
  */
 package it.geosolutions.jaiext.rescale;
 
-import it.geosolutions.jaiext.range.Range;
-
 import java.awt.RenderingHints;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
@@ -28,6 +26,9 @@ import javax.media.jai.ImageLayout;
 import javax.media.jai.ROI;
 
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
 
 /**
  * This RenderedImageFactory class is called by the JAI.create("Rescaling") method for returning a new instance of the RescaleOpImage class. The
@@ -50,12 +51,13 @@ public class RescaleCRIF extends CRIFImpl {
         double[] scales = (double[]) pb.getObjectParameter(0);
         double[] offsets = (double[]) pb.getObjectParameter(1);
         ROI roi = (ROI) pb.getObjectParameter(2);
-        Range rangeND = (Range) pb.getObjectParameter(3);
+        Range noData = (Range) pb.getObjectParameter(3);
+        noData = RangeFactory.convert(noData, source.getSampleModel().getDataType());
         boolean useRoiAccessor = (Boolean) pb.getObjectParameter(4);
         double destinationNoData = pb.getDoubleParameter(5);
         // Creation of the new image
         return new RescaleOpImage(source, layout, hints, scales, offsets, destinationNoData, roi,
-                rangeND, useRoiAccessor);
+                noData, useRoiAccessor);
     }
 
 }

--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleCRIF.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleCRIF.java
@@ -17,13 +17,6 @@
 */
 package it.geosolutions.jaiext.scale;
 
-import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
-import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
-import it.geosolutions.jaiext.interpolators.InterpolationNearest;
-import it.geosolutions.jaiext.range.Range;
-import it.geosolutions.jaiext.translate.TranslateIntOpImage;
-import it.geosolutions.jaiext.utilities.ImageUtilities;
-
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
@@ -47,6 +40,14 @@ import javax.media.jai.ScaleOpImage;
 import com.sun.media.jai.mlib.MlibScaleRIF;
 import com.sun.media.jai.opimage.CopyOpImage;
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
+import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
+import it.geosolutions.jaiext.interpolators.InterpolationNearest;
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
+import it.geosolutions.jaiext.translate.TranslateIntOpImage;
+import it.geosolutions.jaiext.utilities.ImageUtilities;
 
 /**
  * @see ScaleOpImage
@@ -81,6 +82,7 @@ public class ScaleCRIF extends CRIFImpl {
         Interpolation interp = (Interpolation) paramBlock.getObjectParameter(4);
         // Get the Nodata Range
         Range nodata = (Range) paramBlock.getObjectParameter(7);
+        nodata = RangeFactory.convert(nodata, source.getSampleModel().getDataType());
 
         // Get the backgroundValues
         double[] backgroundValues = (double[]) paramBlock.getObjectParameter(8);
@@ -251,10 +253,10 @@ public class ScaleCRIF extends CRIFImpl {
         float trans_y = paramBlock.getFloatParameter(3);
 
         // Get the source dimensions
-        float x0 = (float) source.getMinX();
-        float y0 = (float) source.getMinY();
-        float w = (float) source.getWidth();
-        float h = (float) source.getHeight();
+        float x0 = source.getMinX();
+        float y0 = source.getMinY();
+        float w = source.getWidth();
+        float h = source.getHeight();
 
         // Forward map the source using x0, y0, w and h
         float d_x0 = x0 * scale_x + trans_x;

--- a/jt-stats/src/main/java/it/geosolutions/jaiext/stats/StatisticsRIF.java
+++ b/jt-stats/src/main/java/it/geosolutions/jaiext/stats/StatisticsRIF.java
@@ -17,9 +17,6 @@
 */
 package it.geosolutions.jaiext.stats;
 
-import it.geosolutions.jaiext.range.Range;
-import it.geosolutions.jaiext.stats.Statistics.StatsType;
-
 import java.awt.RenderingHints;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
@@ -29,6 +26,10 @@ import javax.media.jai.ImageLayout;
 import javax.media.jai.ROI;
 
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
+import it.geosolutions.jaiext.stats.Statistics.StatsType;
 
 /**
  * Simple class that provides the RenderedImage create operation by calling a subclass of the {@link StatisticsOpImage}. The input parameters are:
@@ -48,6 +49,7 @@ public class StatisticsRIF implements RenderedImageFactory {
         int yPeriod = pb.getIntParameter(1);
         ROI roi = (ROI) pb.getObjectParameter(2);
         Range noData = (Range) pb.getObjectParameter(3);
+        noData = RangeFactory.convert(noData, source.getSampleModel().getDataType());
         boolean useROIAccessor = (Boolean) pb.getObjectParameter(4);
         int[] bands = (int[]) pb.getObjectParameter(5);
         StatsType[] statsTypes = (StatsType[]) pb.getObjectParameter(6);

--- a/jt-warp/src/main/java/it/geosolutions/jaiext/warp/WarpRIF.java
+++ b/jt-warp/src/main/java/it/geosolutions/jaiext/warp/WarpRIF.java
@@ -17,11 +17,6 @@
 */
 package it.geosolutions.jaiext.warp;
 
-import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
-import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
-import it.geosolutions.jaiext.interpolators.InterpolationNearest;
-import it.geosolutions.jaiext.range.Range;
-
 import java.awt.RenderingHints;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
@@ -35,6 +30,12 @@ import javax.media.jai.ROI;
 import javax.media.jai.Warp;
 
 import com.sun.media.jai.opimage.RIFUtil;
+
+import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
+import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
+import it.geosolutions.jaiext.interpolators.InterpolationNearest;
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
 
 /**
  * A <code>RIF</code> supporting the "Warp" operation in the rendered image layer.
@@ -76,6 +77,7 @@ public class WarpRIF implements RenderedImageFactory {
             source = temp;
         }
         Range noData = (Range) paramBlock.getObjectParameter(4);
+        noData = RangeFactory.convert(noData, source.getSampleModel().getDataType());
         if (interp instanceof InterpolationNearest || interp instanceof javax.media.jai.InterpolationNearest) {
             return new WarpNearestOpImage(source, renderHints, layout, warp, interp, roi, noData, backgroundValues);
         } else if (interp instanceof InterpolationBilinear || interp instanceof javax.media.jai.InterpolationBilinear) {


### PR DESCRIPTION
In the lucky case, the nodata will disappear, otherwise we make sure to use the optimized contains.
I've modified only the most obvious operations, not all of them (for some I was not sure how to proceed).