### PR TITLE
#103 Incorrect ROI property computation when JAI interpolations are used

### DIFF
--- a/jt-affine/src/test/java/it/geosolutions/jaiext/affine/ImageRGBTest.java
+++ b/jt-affine/src/test/java/it/geosolutions/jaiext/affine/ImageRGBTest.java
@@ -19,12 +19,6 @@ package it.geosolutions.jaiext.affine;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import it.geosolutions.jaiext.affine.AffineDescriptor;
-import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
-import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
-import it.geosolutions.jaiext.interpolators.InterpolationNearest;
-import it.geosolutions.jaiext.testclasses.TestData;
-import it.geosolutions.rendered.viewer.RenderedImageBrowser;
 
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
@@ -49,6 +43,9 @@ import org.junit.Test;
 
 import com.sun.media.imageioimpl.plugins.tiff.TIFFImageReader;
 import com.sun.media.imageioimpl.plugins.tiff.TIFFImageReaderSpi;
+
+import it.geosolutions.jaiext.testclasses.TestData;
+import it.geosolutions.rendered.viewer.RenderedImageBrowser;
 
 /**
  * This class extends the TestAffine class and tests the Affine operation on a RGB image. If the user want to see the result, must set the
@@ -195,12 +192,11 @@ public class ImageRGBTest extends TestAffine {
         switch (interpType) {
         case NEAREST_INTERP:
             // Nearest-Neighbor
-            interp = new InterpolationNearest(null, useROIAccessor, destinationNoData, dataType);
+            interp = new javax.media.jai.InterpolationNearest();
             break;
         case BILINEAR_INTERP:
             // Bilinear
-            interp = new InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS, null, useROIAccessor,
-                    destinationNoData, dataType);
+            interp = new javax.media.jai.InterpolationBilinear();
 
             if (hints != null) {
                 hints.add(new RenderingHints(JAI.KEY_BORDER_EXTENDER, BorderExtender
@@ -213,8 +209,7 @@ public class ImageRGBTest extends TestAffine {
             break;
         case BICUBIC_INTERP:
             // Bicubic
-            interp = new InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS, null, useROIAccessor,
-                    destinationNoData, dataType, bicubic2Disabled, DEFAULT_PRECISION_BITS);
+            interp = new javax.media.jai.InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS);
 
             if (hints != null) {
                 hints.add(new RenderingHints(JAI.KEY_BORDER_EXTENDER, BorderExtender

--- a/jt-affine/src/test/java/it/geosolutions/jaiext/affine/TestAffine.java
+++ b/jt-affine/src/test/java/it/geosolutions/jaiext/affine/TestAffine.java
@@ -35,6 +35,7 @@ import java.awt.image.RenderedImage;
 import java.io.IOException;
 
 import javax.media.jai.BorderExtender;
+import javax.media.jai.Interpolation;
 import javax.media.jai.JAI;
 import javax.media.jai.PlanarImage;
 import javax.media.jai.ROI;
@@ -170,27 +171,24 @@ public class TestAffine extends TestBase {
         RenderedImage destinationIMG = null;
 
         // Interpolator initialization
-        InterpolationNearest interpN = null;
-        InterpolationBilinear interpB = null;
-        InterpolationBicubic interpBN = null;
+        Interpolation interpN = null;
+        Interpolation interpB = null;
+        Interpolation interpBN = null;
 
         // Interpolators
         switch (interpType) {
         case NEAREST_INTERP:
             // Nearest-Neighbor
-            interpN = new InterpolationNearest(noDataRange, useROIAccessor, destinationNoData,
-                    dataType);
+            interpN = new javax.media.jai.InterpolationNearest();
 
             // Affine operation
-            destinationIMG = AffineDescriptor.create(sourceImage, transform, interpN, null,
+            destinationIMG = AffineDescriptor.create(sourceImage, transform, interpN, new double[] {destinationNoData},
                     (ROI) roi, useROIAccessor, setDestinationNoData, noDataRange, hints);
-            // destinationIMG = AffineDescriptor.create(sourceImage, transform, new javax.media.jai.InterpolationNearest(), null,hints);
 
             break;
         case BILINEAR_INTERP:
             // Bilinear
-            interpB = new InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS, noDataRange,
-                    useROIAccessor, destinationNoData, dataType);
+            interpB = new javax.media.jai.InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS);
 
             if (hints != null) {
                 hints.add(new RenderingHints(JAI.KEY_BORDER_EXTENDER, BorderExtender
@@ -201,15 +199,13 @@ public class TestAffine extends TestBase {
             }
 
             // Affine operation
-            destinationIMG = AffineDescriptor.create(sourceImage, transform, interpB, null,
+            destinationIMG = AffineDescriptor.create(sourceImage, transform, interpB, new double[] {destinationNoData},
                     (ROI) roi, useROIAccessor, setDestinationNoData, noDataRange, hints);
 
             break;
         case BICUBIC_INTERP:
             // Bicubic
-            interpBN = new InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS, noDataRange,
-                    useROIAccessor, destinationNoData, dataType, bicubic2Disabled,
-                    DEFAULT_PRECISION_BITS);
+            interpBN = new javax.media.jai.InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS);
 
             if (hints != null) {
                 hints.add(new RenderingHints(JAI.KEY_BORDER_EXTENDER, BorderExtender
@@ -220,7 +216,7 @@ public class TestAffine extends TestBase {
             }
 
             // Affine operation
-            destinationIMG = AffineDescriptor.create(sourceImage, transform, interpBN, null,
+            destinationIMG = AffineDescriptor.create(sourceImage, transform, interpBN, new double[] {destinationNoData},
                     (ROI) roi, useROIAccessor, setDestinationNoData, noDataRange, hints);
 
             break;

--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleDescriptor.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleDescriptor.java
@@ -1,6 +1,6 @@
 /* JAI-Ext - OpenSource Java Advanced Image Extensions Library
 *    http://www.geo-solutions.it/
-*    Copyright 2014 GeoSolutions
+*    Copyright 2014 - 2015 GeoSolutions
 
 
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,20 +16,16 @@
 * limitations under the License.
 */
 package it.geosolutions.jaiext.scale;
-import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
-import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
-import it.geosolutions.jaiext.range.Range;
-
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
 import java.awt.image.renderable.RenderableImage;
 import java.util.logging.Logger;
+
 import javax.media.jai.BorderExtender;
 import javax.media.jai.GeometricOpImage;
 import javax.media.jai.Interpolation;
-import javax.media.jai.InterpolationBicubic2;
 import javax.media.jai.JAI;
 import javax.media.jai.OperationDescriptorImpl;
 import javax.media.jai.ParameterBlockJAI;
@@ -48,6 +44,10 @@ import org.jaitools.imageutils.ROIGeometry;
 
 import com.sun.media.jai.util.PropertyGeneratorImpl;
 import com.vividsolutions.jts.geom.Geometry;
+
+import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
+import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
+import it.geosolutions.jaiext.range.Range;
 
 /**
  * This property generator computes the properties for the operation
@@ -112,9 +112,9 @@ class ScalePropertyGenerator extends PropertyGeneratorImpl {
                                   src.getHeight() - interp.getHeight() + 1);
             } else {
                 srcBounds = new Rectangle(src.getMinX(),
-					  src.getMinY(),
-					  src.getWidth(),
-					  src.getHeight());
+                        src.getMinY(),
+                        src.getWidth(),
+                        src.getHeight());
             }
 
             // If necessary, clip the ROI to the effective source bounds.
@@ -131,73 +131,67 @@ class ScalePropertyGenerator extends PropertyGeneratorImpl {
             Rectangle dstBounds = op.getBounds();
             PlanarImage roiImage = null;
             
-            if (interp instanceof InterpolationBilinear) {
-	            // Setting constant image to be scaled as a ROI
-	            
-	            ImageLayout2 layout = new ImageLayout2();
-	            int minx = (int)srcBounds.getMinX();
-	            int miny = (int)srcBounds.getMinY();
-	            int w = (int)srcBounds.getWidth();
-	            int h = (int)srcBounds.getHeight();
-	            layout.setMinX(minx);
-	            layout.setMinY(miny);
-	            layout.setWidth(w);
-	            layout.setHeight(h);
-	            RenderingHints hints = op.getRenderingHints();
-	            hints.add(new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
-	            
-	            final PlanarImage constantImage = ConstantDescriptor.create(new Float(w), new Float(h), new Byte[]{(byte)255}, hints); 
-	            // Scaling constant Image to get scaled roi.
-	            final BorderExtender extender = BorderExtender.createInstance(BorderExtender.BORDER_COPY);
-	            
-	            // Make sure to specify tileCache, tileScheduler, tileRecyclier, by cloning hints.
-	            RenderingHints scalingHints = op.getRenderingHints();
-	            scalingHints.remove(JAI.KEY_IMAGE_LAYOUT);
-	            
-	            if (srcROI instanceof ROIGeometry){
-	            	ROIGeometry roiGeom = (ROIGeometry) srcROI;
-	            	Geometry geom = roiGeom.getAsGeometry();
-	            	if (geom != null && !geom.isEmpty()){
-	            		constantImage.setProperty("roi", srcROI);
-	            	}
-                } else {
-	            		constantImage.setProperty("roi", srcROI);
-	            	}
-	            // Creating scaled roi by the same way (scale,translate factors, Interpolation, source ROI) we scaled the 
-	            // input image.
-//	            if (interp instanceof InterpolationBilinear){ 
-	   
-	            InterpolationBilinear interpolator=(InterpolationBilinear) interp;
-	            
-	            InterpolationBilinear interpBilinear=new InterpolationBilinear(interpolator.getSubsampleBitsH(), null, false, 0, interpolator.getDataType());	                    
-	            
-	            roiImage = new ScaleGeneralOpImage(constantImage, null,scalingHints,extender, interpBilinear,sx, sy, tx, ty,  false, null, null);
-	            
-//	            roiImage = new ScaleBilinearOpImage(constantImage, extender, scalingHints, layout, sx, sy, tx, ty, interp, false);
-	            
-	            //	            } else {
-//	            	roiImage = new ScaleNearestOpImage(constantImage, extender, scalingHints, null, sx, sy, tx, ty, interp);
-//	            }
-            } else {
-            	PlanarImage roiMod = srcROI.getAsImage();
-				ParameterBlock paramBlock = new ParameterBlock();
-				paramBlock.setSource(roiMod, 0);
-				paramBlock.add(Float.valueOf(sx));
-				paramBlock.add(Float.valueOf(sy));
-				paramBlock.add(Float.valueOf(tx));
-				paramBlock.add(Float.valueOf(ty));
-				
+            if (interp instanceof InterpolationBilinear || interp instanceof javax.media.jai.InterpolationBilinear) {
+                // Setting constant image to be scaled as a ROI
 
-				if (interp != null) {
-					 if(interp instanceof InterpolationBicubic){
-					    InterpolationBicubic interpBicubic=(InterpolationBicubic)interp;
-					    InterpolationBilinear interpBilinear= new InterpolationBilinear(interpBicubic.getSubsampleBitsH(), null, false, 0, interpBicubic.getDataType());
-					    paramBlock.add(interpBilinear);
-					}else{
-						paramBlock.add(interp);
-					}
-				}
-				roiImage = JAI.create("Scale", paramBlock);
+                ImageLayout2 layout = new ImageLayout2();
+                int minx = (int) srcBounds.getMinX();
+                int miny = (int) srcBounds.getMinY();
+                int w = (int) srcBounds.getWidth();
+                int h = (int) srcBounds.getHeight();
+                layout.setMinX(minx);
+                layout.setMinY(miny);
+                layout.setWidth(w);
+                layout.setHeight(h);
+                RenderingHints hints = op.getRenderingHints();
+                hints.add(new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
+
+                final PlanarImage constantImage = ConstantDescriptor.create(new Float(w),
+                        new Float(h), new Byte[] { (byte) 255 }, hints);
+                // Scaling constant Image to get scaled roi.
+                final BorderExtender extender = BorderExtender
+                        .createInstance(BorderExtender.BORDER_COPY);
+
+                // Make sure to specify tileCache, tileScheduler, tileRecyclier, by cloning hints.
+                RenderingHints scalingHints = op.getRenderingHints();
+                scalingHints.remove(JAI.KEY_IMAGE_LAYOUT);
+
+                if (srcROI instanceof ROIGeometry) {
+                    ROIGeometry roiGeom = (ROIGeometry) srcROI;
+                    Geometry geom = roiGeom.getAsGeometry();
+                    if (geom != null && !geom.isEmpty()) {
+                        constantImage.setProperty("roi", srcROI);
+                    }
+                } else {
+                    constantImage.setProperty("roi", srcROI);
+                }
+
+                InterpolationBilinear interpBilinear = new InterpolationBilinear(
+                        interp.getSubsampleBitsH(), null, false, 0,
+                        constantImage.getSampleModel().getDataType());
+
+                roiImage = new ScaleGeneralOpImage(constantImage, null, scalingHints, extender,
+                        interpBilinear, sx, sy, tx, ty, false, null, null);
+            } else {
+                PlanarImage roiMod = srcROI.getAsImage();
+                ParameterBlock paramBlock = new ParameterBlock();
+                paramBlock.setSource(roiMod, 0);
+                paramBlock.add(Float.valueOf(sx));
+                paramBlock.add(Float.valueOf(sy));
+                paramBlock.add(Float.valueOf(tx));
+                paramBlock.add(Float.valueOf(ty));
+
+                if (interp != null) {
+                    if (interp instanceof InterpolationBicubic || interp instanceof javax.media.jai.InterpolationBicubic) {
+                        InterpolationBilinear interpBilinear = new InterpolationBilinear(
+                                interp.getSubsampleBitsH(), null, false, 0,
+                                roiMod.getSampleModel().getDataType());
+                        paramBlock.add(interpBilinear);
+                    } else {
+                        paramBlock.add(interp);
+                    }
+                }
+                roiImage = JAI.create("Scale", paramBlock);
             }
             ROI dstROI = new ROI(roiImage, 1);
             

--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleGeneralOpImage.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleGeneralOpImage.java
@@ -307,7 +307,7 @@ public class ScaleGeneralOpImage extends ScaleOpImage {
             computeLoopBynary(srcAccessor, source, dest, destRect, xpos, ypos,yposRoi, xfracvalues,
                     yfracvalues,roi,yposRoi,srcRect.x, srcRect.y, roiIter);
         } else {
-            if (roi != null) {
+            if (hasROI) {
                 computeLoop(srcAccessor, destRect, dstAccessor, xpos, ypos, xfracvalues,
                         yfracvalues, roiAccessor, roiIter, yposRoi);
             } else {

--- a/jt-scale/src/test/java/it/geosolutions/jaiext/scale/CoverageClassTest.java
+++ b/jt-scale/src/test/java/it/geosolutions/jaiext/scale/CoverageClassTest.java
@@ -29,6 +29,7 @@ import java.awt.Rectangle;
 import java.awt.image.DataBuffer;
 import java.awt.image.RenderedImage;
 
+import javax.media.jai.Interpolation;
 import javax.media.jai.PlanarImage;
 import javax.media.jai.ROI;
 import javax.media.jai.ROIShape;
@@ -60,15 +61,11 @@ public class CoverageClassTest extends TestScale {
 
         // Interpolators initialization
         // Nearest-Neighbor
-        InterpolationNearest interpNear = new InterpolationNearest(noDataRange,
-                useROIAccessor, destinationNoData, dataType);
+        Interpolation interpNear = new javax.media.jai.InterpolationNearest();
         // Bilinear
-        InterpolationBilinear interpBil = new InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS,
-                noDataRange, useROIAccessor, destinationNoData, dataType);
+        Interpolation interpBil = new javax.media.jai.InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS);
         // Bicubic
-        InterpolationBicubic interpBic = new InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS,
-                noDataRange, useROIAccessor, destinationNoData, dataType, bicubic2Disabled,
-                DEFAULT_PRECISION_BITS);
+        Interpolation interpBic = new javax.media.jai.InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS);
 
         // ROI creation
         ROIShape roi = roiCreation();

--- a/jt-scale/src/test/java/it/geosolutions/jaiext/scale/ImageRGBTest.java
+++ b/jt-scale/src/test/java/it/geosolutions/jaiext/scale/ImageRGBTest.java
@@ -173,12 +173,11 @@ public class ImageRGBTest extends TestScale {
         switch (interpType) {
         case NEAREST_INTERP:
             // Nearest-Neighbor
-            interp = new InterpolationNearest(null, useROIAccessor, destinationNoData, dataType);
+            interp = new javax.media.jai.InterpolationNearest();
             break;
         case BILINEAR_INTERP:
             // Bilinear
-            interp = new InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS, null, useROIAccessor,
-                    destinationNoData, dataType);
+            interp = new javax.media.jai.InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS);
             if (hints != null) {
                 hints.add(new RenderingHints(JAI.KEY_BORDER_EXTENDER, BorderExtender
                         .createInstance(BorderExtender.BORDER_COPY)));
@@ -190,8 +189,7 @@ public class ImageRGBTest extends TestScale {
             break;
         case BICUBIC_INTERP:
             // Bicubic
-            interp = new InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS, null, useROIAccessor,
-                    destinationNoData, dataType, bicubic2Disabled, DEFAULT_PRECISION_BITS);
+            interp = new javax.media.jai.InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS);
             if (hints != null) {
                 hints.add(new RenderingHints(JAI.KEY_BORDER_EXTENDER, BorderExtender
                         .createInstance(BorderExtender.BORDER_COPY)));

--- a/jt-scale/src/test/java/it/geosolutions/jaiext/scale/TestScale.java
+++ b/jt-scale/src/test/java/it/geosolutions/jaiext/scale/TestScale.java
@@ -182,13 +182,11 @@ public class TestScale extends TestBase {
         switch (interpType) {
         case NEAREST_INTERP:
             // Nearest-Neighbor
-            interp = new InterpolationNearest(noDataRange, useROIAccessor, destinationNoData,
-                    dataType);
+            interp = new javax.media.jai.InterpolationNearest();
             break;
         case BILINEAR_INTERP:
             // Bilinear
-            interp = new InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS, noDataRange,
-                    useROIAccessor, destinationNoData, dataType);
+            interp = new javax.media.jai.InterpolationBilinear(DEFAULT_SUBSAMPLE_BITS);
 
             if (hints != null) {
                 hints.add(new RenderingHints(JAI.KEY_BORDER_EXTENDER, BorderExtender
@@ -201,9 +199,7 @@ public class TestScale extends TestBase {
             break;
         case BICUBIC_INTERP:
             // Bicubic
-            interp = new InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS, noDataRange,
-                    useROIAccessor, destinationNoData, dataType, bicubic2Disabled,
-                    DEFAULT_PRECISION_BITS);
+            interp = new javax.media.jai.InterpolationBicubic(DEFAULT_SUBSAMPLE_BITS);
 
             if (hints != null) {
                 hints.add(new RenderingHints(JAI.KEY_BORDER_EXTENDER, BorderExtender

--- a/jt-utilities/src/main/java/it/geosolutions/rendered/viewer/ImageViewer.java
+++ b/jt-utilities/src/main/java/it/geosolutions/rendered/viewer/ImageViewer.java
@@ -271,10 +271,16 @@ public class ImageViewer extends JPanel
     public void setImage(RenderedImage image)
     {
         this.image = image;
-        display.setImage(image);
-        pixelIter = RandomIterFactory.create(image, null);
-        ipixel = new int[image.getSampleModel().getNumBands()];
-        dpixel = new double[image.getSampleModel().getNumBands()];
+        if(image == null) {
+            display.setVisible(false);
+            pixelIter = null;
+        } else {
+            display.setImage(image);
+            display.setVisible(true);
+            pixelIter = RandomIterFactory.create(image, null);
+            ipixel = new int[image.getSampleModel().getNumBands()];
+            dpixel = new double[image.getSampleModel().getNumBands()];
+        }
     }
 
     public ImageViewer getRelatedViewer()
@@ -285,6 +291,11 @@ public class ImageViewer extends JPanel
     public void setRelatedViewer(ImageViewer relatedViewer)
     {
         this.relatedViewer = relatedViewer;
+    }
+
+    public void setStatusMessage(String message) {
+        status.setText(message);
+        
     }
 
 }

--- a/jt-utilities/src/main/java/it/geosolutions/rendered/viewer/RenderedImageInfoPanel.java
+++ b/jt-utilities/src/main/java/it/geosolutions/rendered/viewer/RenderedImageInfoPanel.java
@@ -190,17 +190,29 @@ public class RenderedImageInfoPanel extends JPanel
         {
             histogramPanel.setImage(PlanarImage.wrapRenderedImage(image));
         }
-        viewer.setImage(image);
+        try {
+            viewer.setImage(image);
+        } catch(Exception e) {
+            viewer.setImage(null);
+            viewer.setStatusMessage("Error:" + e.getMessage());
+            e.printStackTrace();
+        }
         if (showRoi)
         {
-            if (image instanceof RenderedOp)
-            {
-                final Object object = image.getProperty("ROI");
-                if (object instanceof ROI)
+            try {
+                if (image instanceof RenderedOp)
                 {
-                    ROI roi = (ROI) object;
-                    roiViewer.setImage(roi.getAsImage());
+                    final Object object = image.getProperty("ROI");
+                    if (object instanceof ROI)
+                    {
+                        ROI roi = (ROI) object;
+                        roiViewer.setImage(roi.getAsImage());
+                    }
                 }
+            } catch(Exception e) {
+                e.printStackTrace();
+                roiViewer.setImage(null);
+                roiViewer.setStatusMessage("Error:" + e.getMessage());
             }
         }
 
@@ -215,7 +227,7 @@ public class RenderedImageInfoPanel extends JPanel
         try
         {
             image.getWidth();
-            renderingName = image.getCurrentRendering().getClass().getSimpleName();
+            renderingName = image.getCurrentRendering().getClass().getName();
         }
         catch (Exception ignored)
         {
@@ -231,7 +243,7 @@ public class RenderedImageInfoPanel extends JPanel
             }
             
         }
-        hb.dataLine("Name", image.getOperationName() + '(' + renderingName + ')');
+        hb.dataLine("Name", image.getOperationName() + " (" + renderingName + ')');
 
         hb.title("Parameters");
 

--- a/jt-warp/src/main/java/it/geosolutions/jaiext/warp/WarpDescriptor.java
+++ b/jt-warp/src/main/java/it/geosolutions/jaiext/warp/WarpDescriptor.java
@@ -17,6 +17,7 @@
 */
 package it.geosolutions.jaiext.warp;
 
+import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
 import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
 import it.geosolutions.jaiext.range.Range;
 
@@ -131,6 +132,8 @@ class WarpPropertyGenerator extends PropertyGeneratorImpl {
             layout.setMinY(miny);
             layout.setWidth(w);
             layout.setHeight(h);
+            layout.setTileWidth(src.getTileWidth());
+            layout.setTileHeight(src.getTileHeight());
             RenderingHints hints = op.getRenderingHints();
             hints.add(new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout));
 
@@ -148,8 +151,11 @@ class WarpPropertyGenerator extends PropertyGeneratorImpl {
 
             // Creating warped roi by the same way (Warp, Interpolation, source ROI) we warped the
             // input image.
-            if (interp instanceof InterpolationBilinear) {
+            if (interp instanceof InterpolationBilinear || interp instanceof javax.media.jai.InterpolationBilinear) {
                 roiImage = new WarpBilinearOpImage(constantImage, extender, warpingHints,
+                        null, warp, interp, srcROI,null, null);
+            } else if(interp instanceof InterpolationBicubic || interp instanceof javax.media.jai.InterpolationBicubic) {
+                roiImage = new WarpBicubicOpImage(constantImage, extender, warpingHints,
                         null, warp, interp, srcROI,null, null);
             } else {
                 roiImage = new WarpNearestOpImage(constantImage, warpingHints, null, warp,

--- a/jt-warp/src/test/java/it/geosolutions/jaiext/warp/BicubicWarpTest.java
+++ b/jt-warp/src/test/java/it/geosolutions/jaiext/warp/BicubicWarpTest.java
@@ -17,19 +17,17 @@
 */
 package it.geosolutions.jaiext.warp;
 
-import it.geosolutions.jaiext.ConcurrentOperationRegistry;
-import it.geosolutions.jaiext.JAIExt;
-
 import java.awt.geom.AffineTransform;
 import java.awt.image.DataBuffer;
 import java.awt.image.RenderedImage;
 
-import javax.media.jai.JAI;
 import javax.media.jai.WarpAffine;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import it.geosolutions.jaiext.JAIExt;
 
 /**
  * Test class which extends the TestWarp class and executes all the tests with the bicubic interpolation.

--- a/jt-warp/src/test/java/it/geosolutions/jaiext/warp/BilinearWarpTest.java
+++ b/jt-warp/src/test/java/it/geosolutions/jaiext/warp/BilinearWarpTest.java
@@ -17,19 +17,17 @@
 */
 package it.geosolutions.jaiext.warp;
 
-import it.geosolutions.jaiext.ConcurrentOperationRegistry;
-import it.geosolutions.jaiext.JAIExt;
-
 import java.awt.geom.AffineTransform;
 import java.awt.image.DataBuffer;
 import java.awt.image.RenderedImage;
 
-import javax.media.jai.JAI;
 import javax.media.jai.WarpAffine;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import it.geosolutions.jaiext.JAIExt;
 
 /**
  * Test class which extends the TestWarp class and executes all the tests with the bilinear interpolation.


### PR DESCRIPTION
The change fixes some intastanceof, and rewrites the tests to use JAI own interpolation objects when possible to cover the common case (jai-ext should be transparent, we expect the JAI interpolation objects  to be used)