### PR TITLE
Fixing NPE in ZonalStats when no roi list is specified.

### DIFF
--- a/jt-zonal/src/main/java/it/geosolutions/jaiext/zonal/ZonalStatsOpImage.java
+++ b/jt-zonal/src/main/java/it/geosolutions/jaiext/zonal/ZonalStatsOpImage.java
@@ -184,8 +184,7 @@ public class ZonalStatsOpImage extends OpImage {
         isNotIdentity = false;
         if (classPresent) {
             // source image bounds
-            sourceBounds = new Rectangle(source.getMinX(), source.getMinY(), source.getWidth(),
-                    source.getHeight());
+            sourceBounds = createBounds(source);
             if (transform == null) {
                 // If no transformation is set, the classifier bounds are the same of the image bounds
                 inverseTrans = new AffineTransform();
@@ -333,6 +332,9 @@ public class ZonalStatsOpImage extends OpImage {
             this.zoneList = new ArrayList<ZoneGeometry>(1);
 
             this.rois = new ArrayList<ROI>();
+            if (sourceBounds == null) {
+                sourceBounds = createBounds(source);
+            }
             ROI roi = new ROIShape(sourceBounds);
             this.rois.add(roi);
             // Bounds Union
@@ -472,6 +474,13 @@ public class ZonalStatsOpImage extends OpImage {
         caseA = notHasNoData && !hasROI;
         caseB = notHasNoData && hasROI;
         caseC = !notHasNoData && !hasROI;
+    }
+
+    /**
+     * Creates a rectangle from the bounds of the specified image. 
+     */
+    private Rectangle createBounds(RenderedImage source) {
+        return new Rectangle(source.getMinX(), source.getMinY(), source.getWidth(), source.getHeight());
     }
 
     public Raster computeTile(int tileX, int tileY) {

--- a/jt-zonal/src/test/java/it/geosolutions/jaiext/zonal/ZonalStatsTest.java
+++ b/jt-zonal/src/test/java/it/geosolutions/jaiext/zonal/ZonalStatsTest.java
@@ -508,6 +508,46 @@ public class ZonalStatsTest extends TestBase {
 
     }
 
+    @Test
+    /**
+     * Test building up a set of pre-defined ranges and classifying stats for each. 
+     */
+    public void testStatsEntireImageNoROI() {
+
+        // build up the ranges
+        int n = 4;
+        byte min = rangeList[0].get(0).getMin().byteValue();
+        byte max = rangeList[0].get(0).getMax().byteValue();
+        byte delta = (byte)((max - min) / n);
+
+        List<Range> ranges = new ArrayList<Range>();
+        byte b = min;
+        for (int i = 0; i < n; i++) {
+            byte c = (byte) (b + delta);
+            ranges.add(RangeFactory.create(b, true, c, i == n-1));
+
+            b = c;
+        }
+
+        // calculate stats on the entire image 
+        RenderedImage destination = ZonalStatsDescriptor.create(sourceIMG[0],
+            null,
+            null,
+            null, 
+            noDataByte,
+            null,
+            false,
+            bands,
+            new StatsType[]{StatsType.MEAN},
+            ranges,
+            true,
+            null);
+
+        List<ZoneGeometry> result = (List<ZoneGeometry>) destination.getProperty(ZonalStatsDescriptor.ZS_PROPERTY);
+        Map<Range, Statistics[]> stats = result.get(0).getStatsPerBandPerClass(0, 0);
+        assertEquals(4, stats.size());
+    }
+
     public void testZonalStats(RenderedImage source, boolean classifierUsed,
             boolean noDataRangeUsed, boolean roiUsed, boolean useROIAccessor, List<Range> rangeList) {
 


### PR DESCRIPTION
Simple fix ensuring that sourceBounds has been instantiated, in this
case from the entire image bounds.