### PR TITLE
Using standard math notation for exclusive/inclusive intervals.

### DIFF
--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/range/Range.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/range/Range.java
@@ -406,13 +406,13 @@ public abstract class Range {
         if (isMinIncluded()) {
             sb.append("[");
         } else {
-            sb.append("]");
+            sb.append("(");
         }
         sb.append(getMin()).append(", ").append(getMax());
         if (isMaxIncluded()) {
             sb.append("]");
         } else {
-            sb.append("[");
+            sb.append(")");
         }
         return sb.toString();
     }


### PR DESCRIPTION
I found Range.toString() hard to read with the current convention used
for representing an exclusive interval. The idea is that it is more
common to use a round bracket.