### PR TITLE
#140 Import ROIGeometry

### DIFF
--- a/jt-scale/pom.xml
+++ b/jt-scale/pom.xml
@@ -27,6 +27,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>it.geosolutions.jaiext.vectorbin</groupId>
+			<artifactId>jt-vectorbin</artifactId>
+			<version>${project.version}</version>
+		</dependency>		
+		<dependency>
 			<groupId>it.geosolutions.jaiext.translate</groupId>
 			<artifactId>jt-translate</artifactId>
 			<version>${project.version}</version>

--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleDescriptor.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleDescriptor.java
@@ -40,7 +40,7 @@ import javax.media.jai.registry.RenderableRegistryMode;
 import javax.media.jai.registry.RenderedRegistryMode;
 
 import org.jaitools.imageutils.ImageLayout2;
-import org.jaitools.imageutils.ROIGeometry;
+import it.geosolutions.jaiext.vectorbin.ROIGeometry;
 
 import com.sun.media.jai.util.PropertyGeneratorImpl;
 import com.vividsolutions.jts.geom.Geometry;

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/jts/CoordinateSequence2D.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/jts/CoordinateSequence2D.java
@@ -1,0 +1,303 @@
+/* 
+ *  Copyright (c) 2010, Michael Bedward. All rights reserved. 
+ *   
+ *  Redistribution and use in source and binary forms, with or without modification, 
+ *  are permitted provided that the following conditions are met: 
+ *   
+ *  - Redistributions of source code must retain the above copyright notice, this  
+ *    list of conditions and the following disclaimer. 
+ *   
+ *  - Redistributions in binary form must reproduce the above copyright notice, this 
+ *    list of conditions and the following disclaimer in the documentation and/or 
+ *    other materials provided with the distribution.   
+ *   
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR 
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */   
+
+package it.geosolutions.jaiext.jts;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.CoordinateSequence;
+import com.vividsolutions.jts.geom.Envelope;
+
+/**
+ * A lightweight implementation of JTS {@code CoordinateSequence} for 2D points.
+ * 
+ * @author Michael Bedward
+ * @since 1.1
+ * @version $Id$
+ */
+public final class CoordinateSequence2D implements CoordinateSequence, Cloneable {
+
+    private final double[] x;
+    private final double[] y;
+
+    /**
+     * Creates a new {@code CoordinateSequence2D} object with the given 
+     * size.
+     * 
+     * @param n capacity (number of coordinates)
+     */
+    public CoordinateSequence2D(int n) {
+        x = new double[n];
+        y = new double[n];
+    }
+
+    /**
+     * Creates a new {@code CoordinateSequence2D} object from a sequence of
+     * (x,y) pairs.
+     * <pre><code>
+     * // Example: create an object with 3 coordinates specified
+     * // as xy pairs
+     * CoordinateSequence cs = new CoordinateSequence2D(1.1, 1.2, 2.1, 2.2, 3.1, 3.2);
+     * </code></pre>
+     * @param xy x and y values ordered as {@code x0, y0, x1, y1...}; 
+     *        if {@code null} an empty object is created
+     * 
+     * @throws IllegalArgumentException if the number of values in {@code xy} is
+     *         greater than 0 but not even
+     */
+    public CoordinateSequence2D(double... xy) {
+        if (xy == null) {
+            x = new double[0];
+            y = new double[0];
+        } else {
+            if (xy.length % 2 != 0) {
+                throw new IllegalArgumentException("xy must have an even number of values");
+            }
+
+            x = new double[xy.length / 2];
+            y = new double[xy.length / 2];
+            
+            for (int i = 0, k = 0; k < xy.length; i++, k += 2) {
+                x[i] = xy[k];
+                y[i] = xy[k + 1];
+            }
+        }
+    }
+
+    /**
+     * Gets the dimension of points stored by this {@code CoordinateSequence2D}.
+     * 
+     * @return always returns 2
+     */
+    public int getDimension() {
+        return 2;
+    }
+
+    /**
+     * Gets coordinate values at the specified index.
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     * 
+     * @return a new {@code Coordinate} object
+     */
+    public Coordinate getCoordinate(int index) {
+        return new Coordinate(x[index], y[index]);
+    }
+
+    /**
+     * Equivalent to {@link #getCoordinate(int)}.
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     * 
+     * @return a new {@code Coordinate} object
+     */
+    public Coordinate getCoordinateCopy(int index) {
+        return getCoordinate(index);
+    }
+
+    /**
+     * Copies the requested coordinate in the sequence to the supplied
+     * {@code Coordinate} object. 
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     * 
+     * @param coord the destination object; ff {@code null} a new
+     *        {@code Coordinate} will e created.
+     */
+    public void getCoordinate(int index, Coordinate coord) {
+        if (coord == null) {
+            coord = new Coordinate();
+        }
+        
+        coord.x = x[index];
+        coord.y = y[index];
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     */
+    public double getX(int index) {
+        return x[index];
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     */
+    public double getY(int index) {
+        return y[index];
+    }
+
+    /**
+     * Returns the ordinate of a coordinate in this sequence.
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     * 
+     * @param ordinateIndex 0 for the X ordinate or 1 for the Y ordinate
+     * 
+     * @return the ordinate value
+     * 
+     * @throws IllegalArgumentException if {@code ordinateIndex} is not
+     *         either 0 or 1
+     */
+    public double getOrdinate(int index, int ordinateIndex) {
+        switch (ordinateIndex) {
+            case 0:
+                return x[index];
+
+            case 1:
+                return y[index];
+
+            default:
+                throw new IllegalArgumentException("invalid ordinate index: " + ordinateIndex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return x.length;
+    }
+
+    /**
+     * Sets the ordinate of a coordinate in this sequence.
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     * 
+     * @param ordinateIndex 0 for the X ordinate or 1 for the Y ordinate
+     * 
+     * @param value the new ordinate value
+     * 
+     * @throws IllegalArgumentException if {@code ordinateIndex} is not
+     *         either 0 or 1
+     */
+    public void setOrdinate(int index, int ordinateIndex, double value) {
+        switch (ordinateIndex) {
+            case 0:
+                x[index] = value;
+                break;
+
+            case 1:
+                y[index] = value;
+                break;
+
+            default:
+                throw new IllegalArgumentException("invalid ordinate index: " + ordinateIndex);
+        }
+    }
+
+    /**
+     * Sets the X ordinate of the point at the given index.
+     * Equivalent to {@link #setOrdinate}(index, 0, value).
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     * 
+     * @param value the new value
+     */
+    public void setX(int index, double value) {
+        setOrdinate(index, 0, value);
+    }
+
+    /**
+     * Sets the Y ordinate of the point at the given index.
+     * Equivalent to {@link #setOrdinate}(index, 1, value).
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     * 
+     * @param value the new value
+     */
+    public void setY(int index, double value) {
+        setOrdinate(index, 1, value);
+    }
+    
+    /**
+     * Sets the coordinate at the given index.
+     * 
+     * @param index an index &ge;0 and &lt; {@link #size()}
+     * 
+     * @param x the new X ordinate value
+     * @param y the new Y ordinate value
+     */
+    public void setXY(int index, double x, double y) {
+        setOrdinate(index, 0, x);
+        setOrdinate(index, 1, y);
+    }
+    /**
+     * Returns an array of new {@code Coordinate} objects for the point values
+     * in this sequence. 
+     * 
+     * @return array of coordinates
+     */
+    public Coordinate[] toCoordinateArray() {
+        Coordinate[] coords = new Coordinate[x.length];
+
+        for (int i = 0; i < x.length; i++) {
+            coords[i] = new Coordinate(x[i], y[i]);
+        }
+
+        return coords;
+    }
+
+    /**
+     * Returns an envelope which contains {@code env} and all points
+     * in this sequence. If {@code env} contains all points it is 
+     * returned unchanged.
+     * 
+     * @param env the test envelope; if {@code null} a new {@code Envelope} 
+     *        is created
+     * 
+     * @return an envelope that includes {@code env} plus all points
+     *         in this sequence
+     */
+    public Envelope expandEnvelope(Envelope env) {
+        if (env == null) env = new Envelope();
+        
+        for (int i = 0; i < x.length; i++) {
+            env.expandToInclude(x[i], y[i]);
+        }
+        
+        return env;
+    }
+
+    /**
+     * Creates a deep copy of this sequence.
+     * 
+     * @return a new sequence with values 
+     */
+    @Override
+    public Object clone() {
+        CoordinateSequence2D copy = new CoordinateSequence2D(x.length);
+        for (int i = 0; i < x.length; i++) {
+            copy.x[i] = x[i];
+            copy.y[i] = y[i];
+        }
+        
+        return copy;
+    }
+    
+}

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/AbstractLiteIterator.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/AbstractLiteIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.geosolutions.jaiext.vectorbin;
+package it.geosolutions.jaiext.utilities.shape;
 
 import java.awt.geom.PathIterator;
 

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/EmptyIterator.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/EmptyIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.geosolutions.jaiext.vectorbin;
+package it.geosolutions.jaiext.utilities.shape;
 
 /**
  * An iterator for empty geometries. This class was ported back and simplified from GeoTools, with permission from the author(s)

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/GeomCollectionIterator.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/GeomCollectionIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.geosolutions.jaiext.vectorbin;
+package it.geosolutions.jaiext.utilities.shape;
 
 import java.awt.geom.AffineTransform;
 import java.awt.geom.PathIterator;

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/LineIterator.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/LineIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.geosolutions.jaiext.vectorbin;
+package it.geosolutions.jaiext.utilities.shape;
 
 import java.awt.geom.AffineTransform;
 

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/LiteShape.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/LiteShape.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.geosolutions.jaiext.vectorbin;
+package it.geosolutions.jaiext.utilities.shape;
 
 import java.awt.Rectangle;
 import java.awt.Shape;

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/PackedLineIterator.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/PackedLineIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.geosolutions.jaiext.vectorbin;
+package it.geosolutions.jaiext.utilities.shape;
 
 import java.awt.geom.AffineTransform;
 

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/PointIterator.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/PointIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.geosolutions.jaiext.vectorbin;
+package it.geosolutions.jaiext.utilities.shape;
 
 import java.awt.geom.AffineTransform;
 

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/PolygonIterator.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/utilities/shape/PolygonIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.geosolutions.jaiext.vectorbin;
+package it.geosolutions.jaiext.utilities.shape;
 
 import java.awt.geom.AffineTransform;
 

--- a/jt-utilities/src/test/java/it/geosolutions/jaiext/jts/CoordinateSequence2DTest.java
+++ b/jt-utilities/src/test/java/it/geosolutions/jaiext/jts/CoordinateSequence2DTest.java
@@ -1,0 +1,225 @@
+/* 
+ *  Copyright (c) 2010, Michael Bedward. All rights reserved. 
+ *   
+ *  Redistribution and use in source and binary forms, with or without modification, 
+ *  are permitted provided that the following conditions are met: 
+ *   
+ *  - Redistributions of source code must retain the above copyright notice, this  
+ *    list of conditions and the following disclaimer. 
+ *   
+ *  - Redistributions in binary form must reproduce the above copyright notice, this 
+ *    list of conditions and the following disclaimer in the documentation and/or 
+ *    other materials provided with the distribution.   
+ *   
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR 
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */   
+
+package it.geosolutions.jaiext.jts;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for CoordinateSequence2D.
+ * 
+ * @author Michael Bedward
+ * @since 1.1
+ * @version $Id$
+ */
+public class CoordinateSequence2DTest {
+    
+    private static final double TOL = 0.0001;
+    
+    @Test
+    public void emptySequenceInt() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(0);
+        assertEquals(0, cs.size());
+    }
+    
+    @Test
+    public void emptySequenceXY() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(null);
+        assertEquals(0, cs.size());
+    }
+    
+    @Test
+    public void testGetDimension() {
+
+        CoordinateSequence2D cs = new CoordinateSequence2D(1);
+        assertEquals(2, cs.getDimension());
+    }
+
+    @Test
+    public void testGetCoordinate() {
+
+        CoordinateSequence2D cs = new CoordinateSequence2D(1.1, 1.2, 2.1, 2.2);
+        
+        Coordinate c0 = cs.getCoordinate(0);
+        assertEquals(1.1, c0.x, TOL);
+        assertEquals(1.2, c0.y, TOL);
+
+        Coordinate c1 = cs.getCoordinate(1);
+        assertEquals(2.1, c1.x, TOL);
+        assertEquals(2.2, c1.y, TOL);
+    }
+
+    @Test
+    public void testGetCoordinateCopy() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(1.1, 1.2, 2.1, 2.2);
+        Coordinate c0 = cs.getCoordinateCopy(0);
+        assertEquals(1.1, c0.x, TOL);
+        assertEquals(1.2, c0.y, TOL);
+
+        Coordinate c1 = cs.getCoordinateCopy(1);
+        assertEquals(2.1, c1.x, TOL);
+        assertEquals(2.2, c1.y, TOL);
+    }
+
+    @Test
+    public void testGetCoordinate_int_Coordinate() {
+
+        CoordinateSequence2D cs = new CoordinateSequence2D(1.1, 1.2, 2.1, 2.2);
+        Coordinate c = new Coordinate();
+        cs.getCoordinate(0, c);
+        assertEquals(1.1, c.x, TOL);
+        assertEquals(1.2, c.y, TOL);
+
+        cs.getCoordinate(1, c);
+        assertEquals(2.1, c.x, TOL);
+        assertEquals(2.2, c.y, TOL);
+    }
+
+    @Test
+    public void testGetX() {
+
+        CoordinateSequence2D cs = new CoordinateSequence2D(1.2, 3.4);
+        assertEquals(1.2, cs.getX(0), TOL);
+    }
+
+    @Test
+    public void testGetY() {
+
+        CoordinateSequence2D cs = new CoordinateSequence2D(1.2, 3.4);
+        assertEquals(3.4, cs.getY(0), TOL);
+    }
+
+    @Test
+    public void testGetOrdinate() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(1.2, 3.4);
+        assertEquals(1.2, cs.getOrdinate(0, 0), TOL);
+        assertEquals(3.4, cs.getOrdinate(0, 1), TOL);
+    }
+
+    @Test
+    public void testSize() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(42);
+        assertEquals(42, cs.size());
+        
+        cs = new CoordinateSequence2D(0, 1, 2, 3, 4, 5);
+        assertEquals(3, cs.size());
+    }
+
+    @Test
+    public void testSetOrdinate() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(2);
+        cs.setOrdinate(0, 0, 1.1);
+        cs.setOrdinate(0, 1, 1.2);
+        cs.setOrdinate(1, 0, 2.1);
+        cs.setOrdinate(1, 1, 2.2);
+        
+        assertEquals(1.1, cs.getX(0), TOL);
+        assertEquals(1.2, cs.getY(0), TOL);
+        assertEquals(2.1, cs.getX(1), TOL);
+        assertEquals(2.2, cs.getY(1), TOL);
+    }
+
+    @Test
+    public void testSetX() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(2);
+        cs.setX(1, 42);
+        
+        assertEquals(42, cs.getX(1), TOL);
+    }
+
+    @Test
+    public void testSetY() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(2);
+        cs.setY(1, 42);
+        
+        assertEquals(42, cs.getY(1), TOL);
+    }
+
+    @Test
+    public void testSetXY() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(2);
+        cs.setXY(1, 42, -1);
+        
+        assertEquals(42, cs.getX(1), TOL);
+        assertEquals(-1, cs.getY(1), TOL);
+    }
+
+    @Test
+    public void testToCoordinateArray() {
+
+        CoordinateSequence2D cs = new CoordinateSequence2D(1.1, 1.2, 2.1, 2.2, 3.1, 3.2);
+        Coordinate[] coords = cs.toCoordinateArray();
+        
+        assertEquals(3, coords.length);
+        for (int i = 0; i < coords.length; i++) {
+            double x = i + 1.1;
+            double y = i + 1.2;
+            assertEquals(x, coords[i].x, TOL);
+            assertEquals(y, coords[i].y, TOL);
+        }
+    }
+
+    @Test
+    public void testExpandEnvelope() {
+        
+        Envelope env = new Envelope();
+        CoordinateSequence2D cs = new CoordinateSequence2D(-5.0, 10.0, 5.0, -10.0);
+        env = cs.expandEnvelope(env);
+        
+        assertEquals(-5.0, env.getMinX(), TOL);
+        assertEquals(-10.0, env.getMinY(), TOL);
+        assertEquals(5.0, env.getMaxX(), TOL);
+        assertEquals(10.0, env.getMaxY(), TOL);
+    }
+
+    @Test
+    public void testClone() {
+        
+        CoordinateSequence2D cs = new CoordinateSequence2D(1,2,3,4,5,6);
+        CoordinateSequence2D copy = (CoordinateSequence2D) cs.clone();
+        
+        assertTrue(cs != copy);
+        assertEquals(cs.size(), copy.size());
+        
+        for (int i = 0; i < cs.size(); i++) {
+            assertEquals(cs.getX(i), copy.getX(i), TOL);
+            assertEquals(cs.getY(i), copy.getY(i), TOL);
+        }
+    }
+
+}

--- a/jt-vectorbin/src/main/java/it/geosolutions/jaiext/vectorbin/ROIGeometry.java
+++ b/jt-vectorbin/src/main/java/it/geosolutions/jaiext/vectorbin/ROIGeometry.java
@@ -1,0 +1,786 @@
+package it.geosolutions.jaiext.vectorbin;
+
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2016 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * The code was modified from the JAITools project, with permission 
+ * from the author Michael Bedward. 
+ */
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.renderable.ParameterBlock;
+import java.awt.image.renderable.RenderedImageFactory;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.media.jai.Interpolation;
+import javax.media.jai.JAI;
+import javax.media.jai.ParameterBlockJAI;
+import javax.media.jai.PlanarImage;
+import javax.media.jai.ROI;
+import javax.media.jai.ROIShape;
+import it.geosolutions.jaiext.utilities.shape.LiteShape;
+import it.geosolutions.jaiext.jts.CoordinateSequence2D;
+import com.vividsolutions.jts.awt.ShapeReader;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryComponentFilter;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.PrecisionModel;
+import com.vividsolutions.jts.geom.TopologyException;
+import com.vividsolutions.jts.geom.prep.PreparedGeometry;
+import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory;
+import com.vividsolutions.jts.geom.util.AffineTransformation;
+
+
+/**
+ * An ROI class backed by a vector object providing precision and the ability 
+ * to handle massive regions. It has a minimal memory footprint allowing it to 
+ * be used with massive images.
+ * <p>
+ * JAI operations often involve converting ROI objects to images. This class 
+ * implements its {@link #getAsImage()} method using the JAITools "VectorBinarize" 
+ * operator to avoid exhausting available memory when dealing with ROIs that 
+ * cover massive image areas.
+ * <p>
+ * Note that this class can be used to honour floating precision pixel coordinates
+ * by setting the {@code useFixedPrecision} constructor argument to {@code false}.
+ * The effect of the default fixed coordinate precision is to provide equivalent
+ * behaviour to that of the standard {@code ROIShape}, where pixel coordinates
+ * are treated as referring to the upper-left pixel corner.
+ * 
+ * @author Michael Bedward
+ * @author Andrea Aime
+ * @since 1.1
+ * @version $Id$
+ */
+public class ROIGeometry extends ROI {
+    
+    private static final Logger LOGGER = Logger.getLogger(ROIGeometry.class.getName());
+    
+    /** 
+     * Default setting for use of anti-aliasing when drawing the reference
+     * {@code Geometry} during a {@link #getAsImage()} request.
+     * The default value is {@code true} which provides behaviour corresponding
+     * to that of the standard JAI {@code ROIShape} class.
+     */
+    public static final boolean DEFAULT_ROIGEOMETRY_ANTIALISING = true;
+    
+    /** 
+     * Default setting for use of fixed precision ({@code true}).
+     */
+    public static final boolean DEFAULT_ROIGEOMETRY_USEFIXEDPRECISION = false;
+    
+    private boolean useAntialiasing = DEFAULT_ROIGEOMETRY_ANTIALISING;
+    
+    private boolean useFixedPrecision = DEFAULT_ROIGEOMETRY_USEFIXEDPRECISION;
+    
+    private static final long serialVersionUID = 1L;
+    
+    private static final AffineTransformation Y_INVERSION = new AffineTransformation(1, 0, 0, 0, -1, 0);
+    
+    private static final String UNSUPPORTED_ROI_TYPE = 
+            "The argument be either an ROIGeometry or an ROIShape";
+
+    /** The {@code Geometry} that defines the area of inclusion */
+    private final PreparedGeometry theGeom;
+    
+    /** Thread safe cache for the roi image */
+    private volatile PlanarImage roiImage;
+    
+    private final GeometryFactory geomFactory;
+    
+    private final static double tolerance = 1d;
+    private final static PrecisionModel PRECISION = new PrecisionModel(tolerance);
+    // read, remove excess ordinates, force precision and collect
+    private final static GeometryFactory PRECISE_FACTORY = new GeometryFactory(PRECISION);
+    
+    private final static PrecisionModel FLOAT_PRECISION = new PrecisionModel(PrecisionModel.FLOATING_SINGLE);
+    private final static GeometryFactory FLOAT_PRECISION_FACTORY = new GeometryFactory(FLOAT_PRECISION);
+
+    private final CoordinateSequence2D testPointCS;
+    private final com.vividsolutions.jts.geom.Point testPoint;
+    
+    private final CoordinateSequence2D testRectCS;
+    private final Polygon testRect;
+    
+    private RenderingHints hints;
+
+    /**
+     * Constructor which takes a {@code Geometry} object to be used
+     * as the reference against which to test inclusion of image coordinates.
+     * The argument {@code geom} must be either a {@code Polygon} or
+     * {@code MultiPolygon}.
+     * The input geometry is copied so subsequent changes to it will
+     * not be reflected in the {@code ROIGeometry} object.
+     * 
+     * @param geom either a {@code Polygon} or {@code MultiPolygon} object
+     *        defining the area(s) of inclusion.
+     * 
+     * @throws IllegalArgumentException if {@code geom} is {@code null} or
+     *         not an instance of either {@code Polygon} or {@code MultiPolygon}
+     */
+    public ROIGeometry(Geometry geom) {
+        this(geom, DEFAULT_ROIGEOMETRY_ANTIALISING, DEFAULT_ROIGEOMETRY_USEFIXEDPRECISION);
+    }
+    
+    /**
+     * Constructor which takes a {@code Geometry} object and a {@code boolean}
+     * value for whether to use fixed coordinate precision (equivalent to
+     * working with integer pixel coordinates). 
+     * The argument {@code geom} must be either a {@code Polygon} or
+     * {@code MultiPolygon}.
+     * The input geometry is copied so subsequent changes to it will
+     * not be reflected in the {@code ROIGeometry} object.
+     * 
+     * @param geom either a {@code Polygon} or {@code MultiPolygon} object
+     *        defining the area(s) of inclusion.
+     *        
+     * @param useFixedPrecision whether to use fixed precision when comparing
+     *        pixel coordinates to the reference geometry
+     * 
+     * @throws IllegalArgumentException if {@code geom} is {@code null} or
+     *         not an instance of either {@code Polygon} or {@code MultiPolygon}
+     */
+    public ROIGeometry(Geometry geom, final boolean useFixedPrecision) {
+        this(geom, DEFAULT_ROIGEOMETRY_ANTIALISING, useFixedPrecision);
+    }
+    
+    /**
+     * Constructors a new ROIGeometry.
+     * The argument {@code geom} must be either a {@code Polygon} or
+     * {@code MultiPolygon}.
+     * The input geometry is copied so subsequent changes to it will
+     * not be reflected in the {@code ROIGeometry} object.
+     * 
+     * @param geom either a {@code Polygon} or {@code MultiPolygon} object
+     *        defining the area(s) of inclusion.
+     * 
+     * @param antiAliasing whether to use anti-aliasing when converting this
+     *        ROI to an image
+     * 
+     * @param useFixedPrecision whether to use fixed precision when comparing
+     *        pixel coordinates to the reference geometry
+     * 
+     * @throws IllegalArgumentException if {@code geom} is {@code null} or
+     *         not an instance of either {@code Polygon} or {@code MultiPolygon}
+     */
+    public ROIGeometry(Geometry geom, final boolean antiAliasing, final boolean useFixedPrecision) {
+        this(geom, DEFAULT_ROIGEOMETRY_ANTIALISING, useFixedPrecision, null);
+    }
+    
+    /**
+     * Builds a new ROIGeometry.
+     * The argument {@code geom} must be either a {@code Polygon} or
+     * {@code MultiPolygon}.
+     * The input geometry is copied so subsequent changes to it will
+     * not be reflected in the {@code ROIGeometry} object.
+     * 
+     * @param geom either a {@code Polygon} or {@code MultiPolygon} object
+     *        defining the area(s) of inclusion.
+     * 
+     * @param hints The JAI hints to be used when generating the raster equivalent of this ROI       
+     * 
+     * @throws IllegalArgumentException if {@code geom} is {@code null} or
+     *         not an instance of either {@code Polygon} or {@code MultiPolygon}
+     */
+    public ROIGeometry(Geometry geom, final RenderingHints hints) {
+        this(geom, DEFAULT_ROIGEOMETRY_ANTIALISING, DEFAULT_ROIGEOMETRY_USEFIXEDPRECISION, hints);
+    }
+    
+    /**
+     * Fully-specified constructor.
+     * The argument {@code geom} must be either a {@code Polygon} or
+     * {@code MultiPolygon}.
+     * The input geometry is copied so subsequent changes to it will
+     * not be reflected in the {@code ROIGeometry} object.
+     * 
+     * @param geom either a {@code Polygon} or {@code MultiPolygon} object
+     *        defining the area(s) of inclusion.
+     * 
+     * @param antiAliasing whether to use anti-aliasing when converting this
+     *        ROI to an image
+     * 
+     * @param useFixedPrecision whether to use fixed precision when comparing
+     *        pixel coordinates to the reference geometry
+     *        
+     * @param hints The JAI hints to be used when generating the raster equivalent of this ROI       
+     * 
+     * @throws IllegalArgumentException if {@code geom} is {@code null} or
+     *         not an instance of either {@code Polygon} or {@code MultiPolygon}
+     */
+    public ROIGeometry(Geometry geom, final boolean antiAliasing, 
+            final boolean useFixedPrecision, final RenderingHints hints) {
+        if (geom == null) {
+            throw new IllegalArgumentException("geom must not be null");
+        }
+        
+        if (!(geom instanceof Polygon || geom instanceof MultiPolygon)) {
+            throw new IllegalArgumentException("geom must be a Polygon, MultiPolygon");
+        }
+        
+        this.useFixedPrecision = useFixedPrecision;
+        this.hints = hints;
+        
+        Geometry cloned = null; 
+        if (useFixedPrecision){
+            geomFactory = PRECISE_FACTORY;
+            cloned = geomFactory.createGeometry(geom);
+            Coordinate[] coords = cloned.getCoordinates();
+            for (Coordinate coord : coords) {
+                Coordinate cc1 = coord;
+                PRECISION.makePrecise(cc1);
+            }
+            cloned.normalize();
+        } else {
+            geomFactory = FLOAT_PRECISION_FACTORY;
+            cloned = geomFactory.createGeometry(geom);
+            Coordinate[] coords = cloned.getCoordinates();
+            for (Coordinate coord : coords) {
+                Coordinate cc1 = coord;
+                FLOAT_PRECISION.makePrecise(cc1);
+            }
+            cloned.normalize();
+        }
+        
+        theGeom = PreparedGeometryFactory.prepare(cloned);
+        
+        testPointCS = new CoordinateSequence2D(1);
+        testPoint = geomFactory.createPoint(testPointCS);
+
+        testRectCS = new CoordinateSequence2D(5);
+        testRect = geomFactory.createPolygon(geomFactory.createLinearRing(testRectCS), null);
+    }
+
+    /**
+     * Returns a new instance which is the union of this ROI and {@code roi}. 
+     * This is only possible if {@code roi} is an instance of ROIGeometry 
+     * or {@link ROIShape}.
+     * 
+     * @param roi the ROI to add
+     * @return the union as a new instance
+     */
+    @Override
+    public ROI add(ROI roi) {
+        try {
+            final Geometry geom = getGeometry(roi);
+            if (geom != null) {
+                Geometry union = geom.union(theGeom.getGeometry());
+                return buildROIGeometry(union);
+            }
+        } catch(TopologyException e) {
+            if(LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Failed to perform operation using geometries, falling back on raster path", e);
+            }
+        }
+        // fallback on robust path
+        return super.add(roi);
+    }
+
+    /**
+     * Tests if this ROI contains the given point.
+     * 
+     * @param p the point
+     * 
+     * @return {@code true} if the point is within this ROI; 
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(Point p) {
+        return contains(p.getX(), p.getY());
+    }
+
+    /**
+     * Tests if this ROI contains the given point.
+     * 
+     * @param p the point
+     * 
+     * @return {@code true} if the point is within this ROI; 
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(Point2D p) {
+        return contains(p.getX(), p.getY());
+    }
+
+    /**
+     * Tests if this ROI contains the given image location.
+     * 
+     * @param x location X ordinate
+     * @param y location Y ordinate
+     * 
+     * @return {@code true} if the location is within this ROI; 
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(int x, int y) {
+        return contains((double)x, (double)y);
+    }
+
+    /**
+     * Tests if this ROI contains the given image location.
+     * 
+     * @param x location X ordinate
+     * @param y location Y ordinate
+     * 
+     * @return {@code true} if the location is within this ROI; 
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(double x, double y) {
+        testPointCS.setX(0, x);
+        testPointCS.setY(0, y);
+        testPoint.geometryChanged();
+        return theGeom.contains(testPoint);
+    }
+
+    /**
+     * Tests if this ROI contains the given rectangle.
+     * 
+     * @param rect the rectangle
+     * @return {@code true} if the rectangle is within this ROI; 
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(Rectangle rect) {
+        return contains(rect.getMinX(), rect.getMinY(), rect.getWidth(), rect.getHeight());
+    }
+
+    /**
+     * Tests if this ROI contains the given rectangle.
+     * 
+     * @param rect the rectangle
+     * @return {@code true} if the rectangle is within this ROI; 
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(Rectangle2D rect) {
+        return contains(rect.getMinX(), rect.getMinY(), rect.getWidth(), rect.getHeight());
+    }
+
+    /**
+     * Tests if this ROI contains the given rectangle.
+     * 
+     * @param x rectangle origin X ordinate
+     * @param y rectangle origin Y ordinate
+     * @param w rectangle width
+     * @param h rectangle height
+     * 
+     * @return {@code true} if the rectangle is within this ROI; 
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(int x, int y, int w, int h) {
+        return contains((double)x, (double)y, (double)w, (double)h);
+    }
+
+    /**
+     * Tests if this ROI contains the given rectangle.
+     * 
+     * @param x rectangle origin X ordinate
+     * @param y rectangle origin Y ordinate
+     * @param w rectangle width
+     * @param h rectangle height
+     * 
+     * @return {@code true} if the rectangle is within this ROI; 
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean contains(double x, double y, double w, double h) {
+        setTestRect(x, y, w, h);
+        return theGeom.contains(testRect);
+    }
+
+    /**
+     * Returns a new instance which is the exclusive OR of this ROI and {@code roi}. 
+     * This is only possible if {@code roi} is an instance of ROIGeometry 
+     * or {@link ROIShape}.
+     * 
+     * @param roi the ROI to add
+     * @return the union as a new instance
+     */
+    @Override
+    public ROI exclusiveOr(ROI roi) {
+        try {
+            final Geometry geom = getGeometry(roi);
+            if (geom != null) {
+                return buildROIGeometry(theGeom.getGeometry().symDifference(geom));
+            }
+        } catch(TopologyException e) {
+            if(LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Failed to perform operation using geometries, falling back on raster path", e);
+            }
+        }
+        // fallback on robust path
+        return super.exclusiveOr(roi);
+
+    }
+
+    @Override
+    public int[][] getAsBitmask(int x, int y, int width, int height, int[][] mask) {
+        // go the cheap way, only TiledImage seems to be using this method
+        ROI roiImage = new ROI(getAsImage());
+        return roiImage.getAsBitmask(x, y, width, height, mask);
+
+    }
+
+    /**
+     * Gets an image representation of this ROI using the {@code VectorBinarize}
+     * operation. For an ROI with very large bounds but simple shape(s) the 
+     * resulting image has a small memory footprint.
+     * 
+     * @return a new image representing this ROI
+     * @see org.jaitools.media.jai.vectorbinarize.VectorBinarizeDescriptor
+     */
+    @Override
+    public PlanarImage getAsImage() {
+        if (roiImage == null) {
+            synchronized (this) {
+                // this synch idiom works only if roiImage is volatile, keep it as such
+                if (roiImage == null) {
+                    Envelope env = theGeom.getGeometry().getEnvelopeInternal();
+                    int x = (int) Math.floor(env.getMinX());
+                    int y = (int) Math.floor(env.getMinY());
+                    int w = (int) Math.ceil(env.getMaxX()) - x;
+                    int h = (int) Math.ceil(env.getMaxY()) - y;
+
+                    ParameterBlockJAI pb = new ParameterBlockJAI("VectorBinarize");
+                    pb.setParameter("minx", x);
+                    pb.setParameter("miny", y);
+                    pb.setParameter("width", w);
+                    pb.setParameter("height", h);
+                    pb.setParameter("geometry", theGeom);
+                    pb.setParameter("antiAliasing", useAntialiasing);
+                    roiImage = JAI.create("VectorBinarize", pb, hints);
+                }
+            }
+        }
+
+        return roiImage;
+    }
+
+    @Override
+    public LinkedList getAsRectangleList(int x, int y, int width, int height) {
+        Rectangle rect = new Rectangle(x, y, width, height);
+        if (!intersects(rect)) { 
+            // no overlap
+            return null;
+        } else if (theGeom.getGeometry().isRectangle()) {
+            // simple case, the geometry is a rectangle to start with
+            Envelope env = theGeom.getGeometry().getEnvelopeInternal();
+            Envelope intersection = env.intersection(new Envelope(x, x + width, y, y + width));
+            int rx = (int) Math.round(intersection.getMinX());
+            int ry = (int) Math.round(intersection.getMinY());
+            int rw = (int) Math.round(intersection.getMaxX() - rx);
+            int rh = (int) Math.round(intersection.getMaxY() - ry);
+            LinkedList result = new LinkedList();
+            result.add(new Rectangle(rx, ry, rw, rh));
+            return result;
+        } else {
+            // we cannot force the base class to use our image, but
+            // we can create a ROI around it
+            ROI roiImage = new ROI(getAsImage());
+            return roiImage.getAsRectangleList(x, y, width, height);
+        }
+    }
+
+    /**
+     * Gets a new {@link Shape} representing this ROI.
+     * 
+     * @return the shape
+     */
+    @Override
+    public Shape getAsShape() {
+        return new LiteShape(theGeom.getGeometry());
+    }
+    
+    /**
+     * Returns the ROI as a JTS {@code Geometry}.
+     * 
+     * @return the geometry
+     */
+    public Geometry getAsGeometry() {
+        return theGeom.getGeometry();
+    }
+
+    /**
+     * Gets the enclosing rectangle of this ROI.
+     * 
+     * @return a new rectangle
+     */
+    @Override
+    public Rectangle getBounds() {
+        Envelope env = theGeom.getGeometry().getEnvelopeInternal();
+        return new Rectangle((int)env.getMinX(), (int)env.getMinY(), (int)env.getWidth(), (int)env.getHeight());
+    }
+
+    /**
+     * Gets the enclosing double-precision rectangle of this ROI.
+     * 
+     * @return a new rectangle
+     */
+    @Override
+    public Rectangle2D getBounds2D() {
+        Envelope env = theGeom.getGeometry().getEnvelopeInternal();
+        return new Rectangle2D.Double(env.getMinX(), env.getMinY(), env.getWidth(), env.getHeight());
+    }
+
+    @Override
+    public int getThreshold() {
+        return super.getThreshold();
+    }
+
+    /**
+     * Returns a new instance which is the intersection of this ROI and {@code roi}. 
+     * This is only possible if {@code roi} is an instance of ROIGeometry 
+     * or {@link ROIShape}.
+     * 
+     * @param roi the ROI to intersect with
+     * @return the intersection as a new instance
+     */
+    @Override
+    public ROI intersect(ROI roi) {
+        try {
+            final Geometry geom = getGeometry(roi);
+            if (geom != null) {
+                Geometry intersect = geom.intersection(theGeom.getGeometry());
+                return buildROIGeometry(intersect);
+            }
+        } catch(TopologyException e) {
+            if(LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Failed to perform operation using geometries, falling back on raster path", e);
+            }
+        }
+        // fallback on robust path
+        return super.intersect(roi);
+    }
+    
+    /**
+     * Gets a {@link Geometry} from an input {@link ROI}.
+     * 
+     * @param roi the ROI
+     * @return a {@link Geometry} instance from the provided input;
+     * null in case the input roi is neither a geometry, nor a shape. 
+     */
+    private Geometry getGeometry(ROI roi){
+        if (roi instanceof ROIGeometry){
+            return ((ROIGeometry) roi).getAsGeometry();
+        } else if (roi instanceof ROIShape){
+            final Shape shape = ((ROIShape) roi).getAsShape();
+            final Geometry geom = ShapeReader.read(shape, 0, geomFactory);
+            geom.apply(Y_INVERSION);
+            return geom;
+        }
+        return null;
+    }
+
+    /**
+     * Tests if the given rectangle intersects with this ROI.
+     * 
+     * @param rect the rectangle
+     * @return {@code true} if there is an intersection; {@code false} otherwise
+     */
+    @Override
+    public boolean intersects(Rectangle rect) {
+        setTestRect(rect.x, rect.y, rect.width, rect.height);
+        return theGeom.intersects(testRect);
+    }
+
+    /**
+     * Tests if the given rectangle intersects with this ROI.
+     * 
+     * @param rect the rectangle
+     * @return {@code true} if there is an intersection; {@code false} otherwise
+     */
+    @Override
+    public boolean intersects(Rectangle2D rect) {
+        setTestRect(rect.getMinX(), rect.getMinY(), rect.getWidth(), rect.getHeight());
+        return theGeom.intersects(testRect);
+    }
+
+    /**
+     * Tests if the given rectangle intersects with this ROI.
+     * 
+     * @param x rectangle origin X ordinate
+     * @param y rectangle origin Y ordinate
+     * @param w rectangle width
+     * @param h rectangle height
+     * @return {@code true} if there is an intersection; {@code false} otherwise
+     */
+    @Override
+    public boolean intersects(int x, int y, int w, int h) {
+        setTestRect(x, y, w, h);
+        return theGeom.intersects(testRect);
+    }
+
+    /**
+     * Tests if the given rectangle intersects with this ROI.
+     * 
+     * @param x rectangle origin X ordinate
+     * @param y rectangle origin Y ordinate
+     * @param w rectangle width
+     * @param h rectangle height
+     * @return {@code true} if there is an intersection; {@code false} otherwise
+     */
+    @Override
+    public boolean intersects(double x, double y, double w, double h) {
+        setTestRect(x, y, w, h);
+        return theGeom.intersects(testRect);
+    }
+
+    @Override
+    public ROI performImageOp(RenderedImageFactory RIF, ParameterBlock paramBlock, int sourceIndex, RenderingHints renderHints) {
+        return super.performImageOp(RIF, paramBlock, sourceIndex, renderHints);
+    }
+
+    @Override
+    public ROI performImageOp(String name, ParameterBlock paramBlock, int sourceIndex, RenderingHints renderHints) {
+        return super.performImageOp(name, paramBlock, sourceIndex, renderHints);
+    }
+
+    @Override
+    public void setThreshold(int threshold) {
+        super.setThreshold(threshold);
+    }
+
+    /**
+     * Returns a new instance which is the difference of this ROI and {@code roi}. 
+     * This is only possible if {@code roi} is an instance of ROIGeometry 
+     * or {@link ROIShape}.
+     * 
+     * @param roi the ROI to add
+     * @return the union as a new instance
+     */
+    @Override
+    public ROI subtract(ROI roi) {
+        try {
+            final Geometry geom = getGeometry(roi);
+            if (geom != null) {
+                Geometry difference = theGeom.getGeometry().difference(geom);
+                return buildROIGeometry(difference);
+            }
+        } catch(TopologyException e) {
+            if(LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Failed to perform operation using geometries, falling back on raster path", e);
+            }
+        }
+        // fallback on robust path
+        return super.subtract(roi);
+    }
+
+    /**
+     * Returns a new ROI created by applying the given transform to 
+     * this ROI.
+     * 
+     * @param at the transform
+     * @param interp ignored
+     * 
+     * @return the new ROI
+     */
+    @Override
+    public ROI transform(AffineTransform at, Interpolation interp) {
+        return transform(at);
+    }
+
+    /**
+     * Returns a new ROI created by applying the given transform to 
+     * this ROI.
+     * 
+     * @param at the transform
+     * 
+     * @return the new ROI
+     */
+    @Override
+    public ROI transform(AffineTransform at) {
+        Geometry cloned = (Geometry) theGeom.getGeometry().clone();
+        cloned.apply(new AffineTransformation(at.getScaleX(), at.getShearX(), at.getTranslateX(), 
+                at.getShearY(), at.getScaleY(), at.getTranslateY()));
+        if (useFixedPrecision){
+            Geometry fixed = PRECISE_FACTORY.createGeometry(cloned);
+            Coordinate[] coords = fixed.getCoordinates();
+            for (Coordinate coord : coords) {
+                Coordinate precise = coord;
+                PRECISION.makePrecise(precise);
+            }
+            cloned = fixed;
+        }
+        return buildROIGeometry(cloned);
+    }
+
+    /**
+     * Helper function for contains and intersects methods.
+     * 
+     * @param x rectangle origin X ordinate
+     * @param y rectangle origin Y ordinate
+     * @param w rectangle width
+     * @param h rectangle height
+     */
+    private void setTestRect(double x, double y, double w, double h) {
+        testRectCS.setXY(0, x, y);
+        testRectCS.setXY(1, x, y + h);
+        testRectCS.setXY(2, x + w, y + h);
+        testRectCS.setXY(3, x + w, y);
+        testRectCS.setXY(4, x, y);
+        testRect.geometryChanged();
+    }
+    
+    /**
+     * Setup a ROIGeometry on top of a geometry.
+     * It takes care of removing invalid polygon, opened line strings and so on
+     * @param geometry the input geometry to be used as reference to create a new {@link ROIGeometry}
+     * @return a ROI from the input geometry.
+     */
+    private ROI buildROIGeometry(Geometry geometry) {
+        // cleanup the geometry, extract only the polygons, set oriented operations might
+        // have returned a mix of points and lines in the resulting geometries
+        final List<Polygon> polygons = new ArrayList<Polygon>();
+        geometry.apply(new GeometryComponentFilter() {
+
+            public void filter(Geometry geom) {
+                if (geom instanceof Polygon) {
+                    polygons.add((Polygon) geom);
+                }
+            }
+        });
+
+        // build a polygon or a multipolygon
+        Geometry geom = null;
+        if (polygons.size() == 0) {
+            geom = geomFactory.createMultiPolygon(new Polygon[0]);
+        } else if (polygons.size() == 1) {
+            geom = polygons.get(0);
+        } else {
+            Polygon[] polygonArray = (Polygon[]) polygons.toArray(new Polygon[polygons.size()]);
+            geom = geomFactory.createMultiPolygon(polygonArray);
+        }
+
+        return new ROIGeometry(geom, this.useAntialiasing, this.useFixedPrecision, this.hints);
+    }
+
+}

--- a/jt-vectorbin/src/main/java/it/geosolutions/jaiext/vectorbin/VectorBinarizeOpImage.java
+++ b/jt-vectorbin/src/main/java/it/geosolutions/jaiext/vectorbin/VectorBinarizeOpImage.java
@@ -33,13 +33,14 @@ import javax.media.jai.ImageLayout;
 import javax.media.jai.RasterFactory;
 import javax.media.jai.SourcelessOpImage;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.geom.TopologyException;
 import com.vividsolutions.jts.geom.prep.PreparedGeometry;
 import com.vividsolutions.jtsexample.geom.ExtendedCoordinate;
 import com.vividsolutions.jtsexample.geom.ExtendedCoordinateSequence;
+
+import it.geosolutions.jaiext.utilities.shape.LiteShape;
 
 /**
  * Creates a binary image based on tests of pixel inclusion in a polygonal {@code Geometry}. See {@link VectorBinarizeDescriptor} for details.

--- a/jt-vectorbin/src/test/java/it/geosolutions/jaiext/vectorbin/ROIGeometryTest.java
+++ b/jt-vectorbin/src/test/java/it/geosolutions/jaiext/vectorbin/ROIGeometryTest.java
@@ -1,0 +1,1059 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2016 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * The code was modified from the JAITools project, with permission 
+ * from the author Michael Bedward. 
+ */
+
+package it.geosolutions.jaiext.vectorbin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.GeneralPath;
+import java.awt.geom.PathIterator;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.media.jai.ImageLayout;
+import javax.media.jai.JAI;
+import javax.media.jai.ROI;
+import javax.media.jai.ROIShape;
+import javax.media.jai.RenderedOp;
+import javax.media.jai.TileScheduler;
+import javax.media.jai.operator.ExtremaDescriptor;
+import javax.media.jai.operator.FormatDescriptor;
+import javax.media.jai.operator.SubtractDescriptor;
+import it.geosolutions.jaiext.vectorbin.ROIGeometry;
+import it.geosolutions.jaiext.utilities.shape.LiteShape;
+
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.util.AffineTransformation;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+
+import it.geosolutions.jaiext.jts.CoordinateSequence2D;
+import it.geosolutions.jaiext.testclasses.TestBase;
+
+/**
+ * Unit tests for ROIGeometry.
+ * 
+ * @author Michael Bedward
+ * @author Andrea Aime
+ * @author Ugo Moschini
+ */
+public class ROIGeometryTest extends TestBase {
+    
+    // Set this to true to display test ROIs as images.
+    private static final boolean INTERACTIVE = false;
+    
+    // Used to avoid problems with Hudson's headless build if INTERACTIVE
+    // is true.
+    private static boolean headless;
+    
+    // Flag for running on OSX, used to skip some tests
+    private static boolean isOSX;
+    
+    
+    private static GeometryFactory gf = new GeometryFactory();
+    
+    @BeforeClass
+    public static void beforeClass() {
+        GraphicsEnvironment grEnv = GraphicsEnvironment.getLocalGraphicsEnvironment(); 
+        headless = GraphicsEnvironment.isHeadless();
+
+        String osname = System.getProperty("os.name").replaceAll("\\s", "");
+        isOSX = "macosx".equalsIgnoreCase(osname);
+        JAI.setDefaultTileSize(new Dimension(512, 512));
+    }
+    
+    @Test
+    public void testContains_Point() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        java.awt.Point p0 = new java.awt.Point(-1, 2);
+        java.awt.Point p1 = new java.awt.Point(-2, 1);
+        
+        assertTrue(roi.contains(p0));
+        assertFalse(roi.contains(p1));
+    }
+    
+    @Test
+    public void testContains_Point2D() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        Point2D p0 = new Point2D.Double(-1.0, 2.5);
+        Point2D p1 = new Point2D.Double(-2.5, 1.0);
+        
+        assertTrue(roi.contains(p0));
+        assertFalse(roi.contains(p1));
+    }
+    
+    @Test
+    public void testContains_int_int() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        assertTrue(roi.contains(-1, 2));
+        assertFalse(roi.contains(-2, 1));
+    }
+
+    @Test
+    public void testContains_double_double() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        assertTrue(roi.contains(-1.0, 2.5));
+        assertFalse(roi.contains(-2.5, 1.0));
+    }
+    
+    @Test
+    public void testContains_Rectangle() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        Rectangle r = new Rectangle(-1, -2, 4, 6);
+        assertTrue(roi.contains(r));
+        
+        r.width += 1;
+        assertFalse(roi.contains(r));
+    }
+
+    @Test
+    public void testContains_Rectangle2D() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        Rectangle2D r = new Rectangle2D.Double(-1.0, -2.0, 4.0, 6.0);
+        assertTrue(roi.contains(r));
+        
+        r = new Rectangle2D.Double(-1.2, -2.0, 4.0, 6.0);
+        assertFalse(roi.contains(r));
+    }
+
+    @Test
+    public void testContains_intRectArgs() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        assertTrue(roi.contains(-1, -2, 4, 6));
+        assertFalse(roi.contains(-1, -2, 5, 6));
+    }
+    
+    @Test
+    public void testContains_doubleRectArgs() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        assertTrue(roi.contains(-1.0, -2.0, 4.0, 6.0));
+        assertFalse(roi.contains(-1.0, -2.0, 5.0, 6.0));
+    }
+    
+    @Test
+    public void testGetBounds() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        Rectangle expected = new Rectangle(-1, -2, 4, 6);
+        assertTrue( expected.equals(roi.getBounds()) );
+    }
+
+    @Test
+    public void testGetBounds2D() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        Rectangle2D expected = new Rectangle2D.Double(-1.1, -2.2, 4.4, 6.6);
+        Rectangle2D result = roi.getBounds2D();
+
+        assertEquals(expected.getMinX(), result.getMinX(), 0.0001);
+        assertEquals(expected.getMinY(), result.getMinY(), 0.0001);
+        assertEquals(expected.getWidth(), result.getWidth(), 0.0001);
+        assertEquals(expected.getHeight(), result.getHeight(), 0.0001);
+    }
+    
+    @Test
+    public void testIntersects_Rectangle() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        Rectangle r = new Rectangle(0, 0, 10, 10);
+        assertTrue(roi.intersects(r));
+        
+        r.x = r.y = 5;
+        assertFalse(roi.intersects(r));
+    }
+
+    @Test
+    public void testIntersects_Rectangle2D() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        Rectangle2D r = new Rectangle2D.Double(0.0, 0.0, 10.0, 10.0);
+        assertTrue(roi.intersects(r));
+        
+        r = new Rectangle2D.Double(-10.0, -10.0, 5.0, 5.0);
+        assertFalse(roi.intersects(r));
+    }
+
+    @Test
+    public void testIntersects_intRectArgs() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        assertTrue(roi.intersects(0, 0, 10, 10));
+        assertFalse(roi.intersects(-10, -10, 5, 5));
+    }
+
+    @Test
+    public void testIntersects_doubleRectArgs() {
+        ROIGeometry roi = createRectROI(-1.1, -2.2, 3.3, 4.4);
+        assertTrue(roi.intersects(-5.0, -5.0, 5.0, 5.0));
+        assertFalse(roi.intersects(-10.0, -10.0, 5.0, 5.0));
+    }
+    
+    @Test
+    public void canCreateFromEmptyGeometry() {
+        createEmptyROI();
+    }
+    
+    @Test
+    public void emptyROIContainsPoint() {
+        ROIGeometry roi = createEmptyROI();
+        assertFalse(roi.contains(0, 0));
+    }
+    
+    @Test
+    public void emptyROIContainsRect() {
+        ROIGeometry empty = createEmptyROI();
+        assertFalse(empty.contains(0, 0, 1, 1));
+    }
+    
+    @Test 
+    public void addNonEmptyROIToEmpty() {
+        ROIGeometry nonEmpty = createRectROI(0, 0, 10, 10);
+        ROIGeometry empty = createEmptyROI();
+        ROI result = empty.add(nonEmpty);
+        
+        assertTrue( result.getBounds().equals(nonEmpty.getBounds()) );
+    }
+    
+    @Test
+    public void addEmptyROIToNonEmptyROI() {
+        ROIGeometry nonEmpty = createRectROI(0, 0, 10, 10);
+        ROIGeometry empty = createEmptyROI();
+        ROI result = nonEmpty.add(empty);
+        
+        assertTrue( result.getBounds().equals(nonEmpty.getBounds()) );
+    }
+
+    @Test
+    public void testCheckerBoard() throws Exception {
+        String wkt = "MULTIPOLYGON (((4 4, 4 0, 8 0, 8 4, 4 4)), ((4 4, 4 8, 0 8, 0 4, 4 4)))";
+        MultiPolygon poly = (MultiPolygon) new WKTReader().read(wkt);
+
+        ROIGeometry g = new ROIGeometry(poly);
+        ROIShape shape = getEquivalentROIShape(g);
+        
+        assertROIEquivalent(g, shape, "Checkerboard");
+    }
+    
+    @Test
+    public void testLargeConcurrentCheckerBoard() throws Exception {
+        String wkt = "MULTIPOLYGON (((400 400, 400 0, 800 0, 800 400, 400 400)), ((400 400, 400 800, 0 800, 0 400, 400 400)))";
+        MultiPolygon poly = (MultiPolygon) new WKTReader().read(wkt);
+
+        ImageLayout layout = new ImageLayout(0, 0, 800, 800, 0, 0, 10, 10, null, null);
+        RenderingHints hints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, layout);
+        ROIGeometry g = new ROIGeometry(poly, hints);
+        RenderedOp image = (RenderedOp) g.getAsImage();
+
+        // start parallel prefetching
+        TileScheduler ts = (TileScheduler) image.getRenderingHint(JAI.KEY_TILE_SCHEDULER);
+        ts.setParallelism(32);
+        ts.setPrefetchParallelism(32);
+        List<java.awt.Point> tiles = new ArrayList<java.awt.Point>();
+        for (int i = 0; i < image.getNumXTiles(); i++) {
+            for (int j = 0; j < image.getNumYTiles(); j++) {
+                tiles.add(new java.awt.Point(image.getMinTileX() + i, image.getMinTileY() + j));
+            }
+        }
+        java.awt.Point[] tileArray = (java.awt.Point[]) tiles.toArray(new java.awt.Point[tiles.size()]);
+        ts.prefetchTiles(image, tileArray);
+        
+        // check tile by tile
+        assertEquals(0, image.getMinX());
+        assertEquals(0, image.getMinY());
+        assertEquals(10, image.getTileWidth());
+        assertEquals(10, image.getTileHeight());
+        for (int x = 0; x < image.getNumXTiles(); x++) {
+            for (int y = 0; y < image.getNumYTiles(); y++) {
+                Raster tile = image.getTile(x, y);
+                int[] pixel = new int[1];
+                tile.getPixel(tile.getMinX(), tile.getMinY(), pixel);
+                if(x < 40 && y < 40 || x >= 40 && y >= 40) {
+                    assertEquals("Expected 0 at x = " + x + ", y = " + y, 0, pixel[0]);
+                } else {
+                    assertEquals("Expected 1 at x = " + x + ", y = " + y, 1, pixel[0]);
+                }
+            }
+        }
+    }
+
+    
+    @Test
+    public void testTopologyException() throws Exception {
+        String wkt = "POLYGON ((4 4, 4 0, 8 0, 8 4, 4 4, 4 0, 8 0, 8 2, 4 4))";
+        Polygon poly = (Polygon) new WKTReader().read(wkt);
+
+        ROIGeometry g = new ROIGeometry(poly);
+        assertROIEquivalent(g, g, "Deal with Topology exception");
+        
+    }
+    
+    @Test
+    public void testFractional() throws Exception {
+        String wkt = "POLYGON ((0.4 0.4, 0.4 5.6, 4.4 5.6, 4.4 0.4, 0.4 0.4))";
+        Polygon poly = (Polygon) new WKTReader().read(wkt);
+
+        ROIGeometry g = new ROIGeometry(poly);
+        ROIShape shape = getEquivalentROIShape(g);
+        
+        assertROIEquivalent(g, shape, "Fractional");
+    }
+    
+    @Test
+    public void testFractionalUnion() throws Exception {
+        // this odd beast is a real world case that was turned into a test
+        // due to the amount of blood and tears it took to get it to work
+        String[] coords = new String[] {
+                "1750 1312.5, 508 1312.5, 508 1609, 1750 1609, 1750 1312.5",
+                "508 875, 508 1312, 1750 1312, 1750 875, 508 875",
+                "508 875, 1750 875, 1750 437.5, 508 437.5, 508 875",
+                "508 377, 508 437, 1750 437, 1750 377, 508 377" };
+        String[] wkts = new String[] { "POLYGON ((" + coords[0] + "))",
+                "POLYGON ((" + coords[1] + "))", "POLYGON ((" + coords[2] + "))",
+                "POLYGON ((" + coords[3] + "))" };
+        final int size = wkts.length;
+        final Polygon[] polygons = new Polygon[size];
+        final ROIGeometry[] roiGeometries = new ROIGeometry[size];
+        final ROIShape[] roiShapes = new ROIShape[size];
+        ROI unionGeometry = null;
+        ROI unionShape = null;
+        for (int i = 0; i < size; i++) {
+            polygons[i] = (Polygon) new WKTReader().read(wkts[i]);
+            roiGeometries[i] = new ROIGeometry(polygons[i]);
+            final GeneralPath gp = new GeneralPath();
+            final String[] wkt = coords[i].split(",");
+            final int segments = wkt.length;
+            for (int k = 0; k < segments; k++) {
+                String[] x_y = wkt[k].trim().split(" ");
+                if (k == 0) {
+                    gp.moveTo(Float.valueOf(x_y[0]), Float.valueOf(x_y[1]));
+                } else {
+                    gp.lineTo(Float.valueOf(x_y[0]), Float.valueOf(x_y[1]));
+                }
+            }
+            roiShapes[i] = new ROIShape(gp);
+            if (i == 0) {
+                unionGeometry = new ROIGeometry(((ROIGeometry) roiGeometries[i]).getAsGeometry());
+                unionShape = roiShapes[0];
+            } else {
+                unionGeometry = unionGeometry.add(roiGeometries[i]);
+                unionShape = unionShape.add(roiShapes[i]);
+            }
+        }
+        if (INTERACTIVE) {
+            printRoiShape((ROIShape) unionShape, "unionShape");
+            System.out.println(((ROIGeometry) unionGeometry).getAsGeometry());
+            Shape shape = new LiteShape(((ROIGeometry) unionGeometry).getAsGeometry());
+            printShape(shape, "unionGeometry");
+        }
+
+        assertROIEquivalent(unionGeometry, unionShape, "Fractional union");
+    }
+    
+    @Test 
+    public void testCircles() throws Exception {
+        if (isOSX) {
+            System.out.println("skipping testCircles on OSX");
+        } else {
+            final int buffers[] = new int[]{3, 5, 7, 8, 10, 15, 20};
+            for (int i = 0; i < buffers.length; i++) {
+                Point p = new GeometryFactory().createPoint(new Coordinate(10, 10));
+                Geometry buffer = p.buffer(buffers[i]);
+
+                ROIGeometry g = new ROIGeometry(buffer);
+                ROIShape shape = getEquivalentROIShape(g);
+
+                assertROIEquivalent(g, shape, "Circle");
+            }
+        }
+    }
+    
+    @Test
+    @Ignore("not working on any platform ?")
+    public void testUnion() throws Exception {
+        Point p1 = new GeometryFactory().createPoint(new Coordinate(10, 10)); 
+        Point p2 = new GeometryFactory().createPoint(new Coordinate(20, 10));
+        Geometry buffer1 = p1.buffer(15);
+        Geometry buffer2 = p2.buffer(15);
+        
+        ROIGeometry rg1 = new ROIGeometry(buffer1);
+        ROIGeometry rg2 = new ROIGeometry(buffer2);
+                
+        ROIShape rs1 = getEquivalentROIShape(rg1);
+        ROIShape rs2 = getEquivalentROIShape(rg2);
+
+        assertROIEquivalent(rg1, rs1, "circle 1 ROIG, circle 1 ROIS");
+        assertROIEquivalent(rg2, rs2, "circle 2 ROIG, circle 2 ROIS");
+    }
+    
+    @Test
+    @Ignore("not working on any platform ?")
+    public void testIntersect() throws Exception {
+        Point p1 = new GeometryFactory().createPoint(new Coordinate(10, 10)); 
+        Point p2 = new GeometryFactory().createPoint(new Coordinate(20, 10));
+        Geometry buffer1 = p1.buffer(15);
+        Geometry buffer2 = p2.buffer(15);
+        
+        ROIGeometry rg1 = new ROIGeometry(buffer1);
+        ROIGeometry rg2 = new ROIGeometry(buffer2);
+        ROI rgIntersection = rg1.intersect(rg2);
+        
+        ROIShape rs1 = getEquivalentROIShape(rg1);
+        ROIShape rs2 = getEquivalentROIShape(rg2);
+        ROI rsIntersection = rs1.intersect(rs2);
+
+        assertROIEquivalent(rgIntersection, rsIntersection, "Intersection");
+    }
+    
+    @Test
+    public void intersectImageROI() throws ParseException {
+        ROI leftRight = createLeftRightROIImage();
+        ROIGeometry topBottom = createTopBottomROIGeometry();
+        
+        // intersect the image roi from the geom one
+        ROI result = topBottom.intersect(leftRight);
+        
+        // checks the quadrants
+        assertTrue(result.contains(64, 64));
+        assertFalse(result.contains(192, 64));
+        assertFalse(result.contains(64, 192));
+        assertFalse(result.contains(192, 192));
+    }
+
+    @Test
+    public void intersectInvalidPolygon() throws ParseException, IOException {
+        ROI leftRight = createLeftRightROIGeometry();
+        ROIGeometry bowTie = createBowTieROIGeometry();
+        
+        // xor them, the invalid geometry should cause a topology exception and a fallback
+        // onto the more robust raster path
+        ROI result = bowTie.intersect(leftRight);
+        
+        // sample and check points 
+        assertTrue(result.contains(64, 64));
+        assertFalse(result.contains(192, 64));
+        assertFalse(result.contains(64, 192));
+        assertFalse(result.contains(192, 192));
+    }
+    
+    @Test
+    public void testSubtract() throws Exception {
+        Point p1 = new GeometryFactory().createPoint(new Coordinate(10, 10)); 
+        Point p2 = new GeometryFactory().createPoint(new Coordinate(20, 10));
+        Geometry buffer1 = p1.buffer(15);
+        Geometry buffer2 = p2.buffer(15);
+        
+        ROIGeometry rg1 = new ROIGeometry(buffer1);
+        ROIGeometry rg2 = new ROIGeometry(buffer2);
+        ROI rgSubtract = rg1.subtract(rg2);
+        
+        ROIShape rs1 = getEquivalentROIShape(rg1);
+        ROIShape rs2 = getEquivalentROIShape(rg2);
+        ROI rsSubtract = rs1.subtract(rs2);
+
+        assertROIEquivalent(rgSubtract, rsSubtract, "Subtract");
+    }
+    
+    @Test
+    public void subtractImageROI() throws ParseException {
+        ROI leftRight = createLeftRightROIImage();
+        ROIGeometry topBottom = createTopBottomROIGeometry();
+        
+        // subtract the image roi from the geom one
+        ROI result = topBottom.subtract(leftRight);
+        
+        // checks the quadrants
+        assertFalse(result.contains(64, 64));
+        assertTrue(result.contains(192, 64));
+        assertFalse(result.contains(64, 192));
+        assertFalse(result.contains(192, 192));
+    }
+
+    @Test
+    public void subtractInvalidPolygon() throws ParseException, IOException {
+        ROI leftRight = createLeftRightROIGeometry();
+        ROIGeometry bowTie = createBowTieROIGeometry();
+        
+        // subtract them, the invalid geometry should cause a topology exception and a fallback
+        // onto the more robust raster path
+        ROI result = bowTie.subtract(leftRight);
+        
+        // sample and check points 
+        assertFalse(result.contains(64, 64));
+        assertTrue(result.contains(192, 64));
+        assertFalse(result.contains(64, 192));
+        assertFalse(result.contains(192, 192));
+    }
+    
+    @Test
+    public void testXor() throws Exception {
+        if (isOSX) {
+            System.out.println("skipping testXor on OSX");
+        } else {
+            Point p1 = new GeometryFactory().createPoint(new Coordinate(10, 10));
+            Point p2 = new GeometryFactory().createPoint(new Coordinate(20, 10));
+            Geometry buffer1 = p1.buffer(15);
+            Geometry buffer2 = p2.buffer(15);
+
+            ROIGeometry rg1 = new ROIGeometry(buffer1);
+            ROIGeometry rg2 = new ROIGeometry(buffer2);
+            ROI rgXor = rg1.exclusiveOr(rg2);
+
+            ROIShape rs1 = getEquivalentROIShape(rg1);
+            ROIShape rs2 = getEquivalentROIShape(rg2);
+            ROI rsXor = rs1.exclusiveOr(rs2);
+
+            assertROIEquivalent(rgXor, rsXor, "Xor");
+        }
+    }
+    
+    @Test
+    public void xorImageROI() throws ParseException {
+        ROI leftRight = createLeftRightROIImage();
+        ROIGeometry topBottom = createTopBottomROIGeometry();
+        
+        // xor the image roi from the geom one
+        ROI result = topBottom.exclusiveOr(leftRight);
+        
+        // checks the quadrants
+        assertFalse(result.contains(64, 64));
+        assertTrue(result.contains(192, 64));
+        assertTrue(result.contains(64, 192));
+        assertFalse(result.contains(192, 192));
+    }
+
+    @Test
+    public void xorInvalidPolygon() throws ParseException, IOException {
+        ROI leftRight = createLeftRightROIGeometry();
+        ROIGeometry bowTie = createBowTieROIGeometry();
+        
+        // xor them, the invalid geometry should cause a topology exception and a fallback
+        // onto the more robust raster path
+        ROI result = bowTie.exclusiveOr(leftRight);
+        
+        // sample and check points 
+        assertFalse(result.contains(64, 64));
+        assertTrue(result.contains(192, 64));
+        assertTrue(result.contains(64, 192));
+        assertFalse(result.contains(192, 192));
+        // the two "holes" inside the bowtie
+        assertTrue(result.contains(120, 32));
+        assertTrue(result.contains(120, 96));
+        assertFalse(result.contains(140, 32));
+        assertFalse(result.contains(140, 96));
+    }
+    
+    @Test
+    public void testRotatedRectangle() throws Exception {
+        if (isOSX) {
+            System.out.println("skipping testRotatedRectangle on OSX");
+        } else {
+            Polygon polygon = (Polygon) new WKTReader().read("POLYGON((20 0, 50 -30, 30 -50, 0 -20, 20 0))");
+
+            ROIGeometry g = new ROIGeometry(polygon);
+            ROIShape shape = getEquivalentROIShape(g);
+
+            assertROIEquivalent(g, shape, "RotatedRectangle");
+        }
+    }
+    
+    @Test
+    public void testRotatedRectangleUnion() throws Exception {
+        if (isOSX) {
+            System.out.println("skipping testRotatedRectangleUnion on OSX");
+        } else {
+            Polygon polygon1 = (Polygon) new WKTReader().read("POLYGON((20 0, 50 -30, 30 -50, 0 -20, 20 0))");
+            Polygon polygon2 = (Polygon) new WKTReader().read("POLYGON((60 -40, 80 -20, 40 20, 20 0, 60 -40))");
+
+            ROIGeometry geom1 = new ROIGeometry(polygon1);
+            ROIShape shape1 = getEquivalentROIShape(geom1);
+
+            ROIGeometry geom2 = new ROIGeometry(polygon2);
+            ROIShape shape2 = getEquivalentROIShape(geom2);
+
+            final ROI geomUnion = geom1.add(geom2);
+            final ROI shapeUnion = shape1.add(shape2);
+
+            assertROIEquivalent(geomUnion, shapeUnion, "RotatedUnion");
+        }
+    }
+    
+    @Test
+    public void testRotatedRectangleIntersection() throws Exception {
+        if (isOSX) {
+            System.out.println("skipping testRotatedRectangleIntersection on OSX");
+        } else {
+            Polygon polygon1 = (Polygon) new WKTReader().read("POLYGON((20 0, 50 -30, 30 -50, 0 -20, 20 0))");
+            Polygon polygon2 = (Polygon) new WKTReader().read("POLYGON((40 -40, 60 -20, 20 20, 0 0, 40 -40))");
+
+            ROIGeometry geom1 = new ROIGeometry(polygon1);
+            ROIShape shape1 = getEquivalentROIShape(geom1);
+
+            ROIGeometry geom2 = new ROIGeometry(polygon2);
+            ROIShape shape2 = getEquivalentROIShape(geom2);
+
+            final ROI geomUnion = geom1.intersect(geom2);
+            final ROI shapeUnion = shape1.intersect(shape2);
+
+            assertROIEquivalent(geomUnion, shapeUnion, "RotatedIntersection");
+        }
+    }
+    
+    @Test
+    public void testUnionFractional() throws Exception{
+        final String geom1 = "POLYGON ((256.0156254550953 384.00000013906043, 384.00000082678343 384.00000013906043, 384.00000082678343 256.00000005685433, 256.0000004550675 256.00000005685433, 256.0000004550675 384.00000013906043, 256.0156254550953 384.00000013906043))"; 
+        final String geom2 = "POLYGON ((384.0156256825708 128.00000008217478, 512.0000010543083 128.00000008217478, 512.0000010543083 -0.0000000000291038, 384.00000068254303 -0.0000000000291038, 384.00000068254303 128.00000008217478, 384.0156256825708 128.00000008217478))";
+        
+        final WKTReader wktReader = new WKTReader();
+        final Geometry geometry1 = wktReader.read(geom1);
+        final Geometry geometry2 = wktReader.read(geom2);
+
+        final ROIGeometry roiGeom1 = new ROIGeometry(geometry1);
+        final ROIGeometry roiGeom2 = new ROIGeometry(geometry2);
+        final ROI roiGeometryUnion = roiGeom1.add(roiGeom2);
+        
+        final ROIShape roiShape1 = getEquivalentROIShape(roiGeom1);
+        final ROIShape roiShape2 = getEquivalentROIShape(roiGeom2);
+        final ROI roiShapeUnion = roiShape1.add(roiShape2);
+        
+        assertROIEquivalent(roiGeometryUnion, roiShapeUnion, "Union");
+    }
+    
+    @Test
+    public void testUnionTransformedFractional() throws Exception {
+        if (isOSX) {
+            System.out.println("skipping testUnionTransformedFractional on OSX");
+        } else {
+            final String geom1 = "POLYGON ((256.0156254550953 384.00000013906043, 384.00000082678343 384.00000013906043, 384.00000082678343 256.00000005685433, 256.0000004550675 256.00000005685433, 256.0000004550675 384.00000013906043, 256.0156254550953 384.00000013906043))";
+            final String geom2 = "POLYGON ((384.0156256825708 128.00000008217478, 512.0000010543083 128.00000008217478, 512.0000010543083 -0.0000000000291038, 384.00000068254303 -0.0000000000291038, 384.00000068254303 128.00000008217478, 384.0156256825708 128.00000008217478))";
+
+            final WKTReader wktReader = new WKTReader();
+            final Geometry geometry1 = wktReader.read(geom1);
+            final Geometry geometry2 = wktReader.read(geom2);
+            geometry1.apply(new AffineTransformation(1.1, 1.1, 0, 0, 1.1, 0));
+            geometry2.apply(new AffineTransformation(0, 1.1, 0, 1.1, 0, 0));
+
+            final ROIGeometry roiGeom1 = new ROIGeometry(geometry1);
+            final ROIGeometry roiGeom2 = new ROIGeometry(geometry2);
+            final ROI roiGeometryUnion = roiGeom1.add(roiGeom2);
+
+            final ROIShape roiShape1 = getEquivalentROIShape(roiGeom1);
+            final ROIShape roiShape2 = getEquivalentROIShape(roiGeom2);
+            final ROI roiShapeUnion = roiShape1.add(roiShape2);
+
+            assertROIEquivalent(roiGeometryUnion, roiShapeUnion, "Union");
+        }
+    }
+    
+    @Test
+    public void unionImageROI() throws ParseException {
+        ROI leftRight = createLeftRightROIImage();
+        ROIGeometry topBottom = createTopBottomROIGeometry();
+        
+        // add them
+        ROI result = topBottom.add(leftRight);
+        
+        // checks the quadrants
+        assertTrue(result.contains(64, 64));
+        assertTrue(result.contains(192, 64));
+        assertTrue(result.contains(64, 192));
+        assertFalse(result.contains(192, 192));
+    }
+
+    @Test
+    public void unionInvalidPolygon() throws ParseException, IOException {
+        ROI leftRight = createLeftRightROIGeometry();
+        ROIGeometry bowTie = createBowTieROIGeometry();
+        
+        // add them, the invalid geometry should cause a topology exception and a fallback
+        // onto the more robust raster path
+        ROI result = bowTie.add(leftRight);
+        
+        // sample and check points 
+        assertTrue(result.contains(64, 64));
+        assertTrue(result.contains(192, 64));
+        assertTrue(result.contains(64, 192));
+        assertFalse(result.contains(192, 192));
+        // in the holes left by the bowtie
+        assertFalse(result.contains(130, 32));
+        assertFalse(result.contains(130, 96));
+    }
+    
+    @Test
+    public void testRectangleListSimple() throws ParseException {
+        ROI leftRight = createLeftRightROIGeometry();
+        
+        // try with an area larger than the ROI
+        LinkedList rectangles = leftRight.getAsRectangleList(-50, -50, 500, 500);
+        assertSingleLeftRectangle(rectangles, 0, 0, 128, 256);
+        
+        // just as bit as the ROI
+        rectangles = leftRight.getAsRectangleList(0, 0, 256, 256);
+        assertSingleLeftRectangle(rectangles, 0, 0, 128, 256);
+        
+        // a subset, checks if intersection actually works
+        rectangles = leftRight.getAsRectangleList(64, 64, 64, 64);
+        assertSingleLeftRectangle(rectangles, 64, 64, 64, 64);
+        
+        // fully outside
+        rectangles = leftRight.getAsRectangleList(130, 0, 64, 64);
+        assertNull(rectangles);
+    }
+
+    private void assertSingleLeftRectangle(LinkedList rectangles, int x, int y, int w, int h) {
+        assertEquals(1, rectangles.size());
+        Rectangle r = (Rectangle) rectangles.getFirst();
+        assertRectangle(x, y, w, h, r);
+    }
+
+    private void assertRectangle(int x, int y, int w, int h, Rectangle r) {
+        assertEquals(x, r.x);
+        assertEquals(y, r.y);
+        assertEquals(w, r.width);
+        assertEquals(h, r.height);
+    }
+    
+    @Test
+    public void testRectangleListBowTie() throws ParseException {
+        ROI bowTie = createBowTieROIGeometry();
+        
+        // try with an area larger than the ROI
+        LinkedList rectangles = bowTie.getAsRectangleList(-50, -50, 500, 500);
+        assertEquals(254, rectangles.size());
+        int expectedWidth = 1;
+        
+        // the pattern is two rectangles on the opposite sides, with increasing width,
+        // until we reach the center, where rasterization generates two rectangles
+        // with a height of 2, but no touch in the central point)
+        int y = 0;
+        for (int i = 0; i < 254; i++) {
+            boolean even = (i % 2) == 0;
+            int x = even ? 0 : 256 - expectedWidth;
+            
+            Rectangle r = (Rectangle) rectangles.get(i);
+            assertEquals(x, r.x);
+            assertEquals(y, r.y);
+            assertEquals(expectedWidth, r.width);
+            
+            if(i == 126 || i == 127 ) {
+                assertEquals(2, r.height);
+            } else {
+                assertEquals(1, r.height);
+            }
+            
+            // if it's not a even rectangle, we're moving to the
+            // next row, update expected width and expected y
+            if(!even) {
+                if(i < 126) {
+                    expectedWidth += 2;
+                } else {
+                    expectedWidth -= 2;
+                }
+                
+                // in the middle we have the two rectangles side by side
+                // with a height of 2
+                if(i == 127) {
+                    y += 2;
+                } else {
+                    y++;
+                }
+            }
+        }
+    }
+    
+    @Test
+    public void testRectangleListSimpleReduction() throws IOException, ParseException {
+        // create a simple, but not rectangular, shape, that should result in only
+        // two rectangles
+        ROIGeometry leftRight = createLeftRightROIGeometry();
+        ROIGeometry topRight = createTopBottomROIGeometry();
+        ROI threeQuarters = leftRight.add(topRight);
+        
+        LinkedList rectangles = threeQuarters.getAsRectangleList(0, 0, 256, 256);
+        assertEquals(2, rectangles.size());
+        Rectangle r1 = (Rectangle) rectangles.get(0);
+        assertRectangle(0, 0, 256, 128, r1);
+        Rectangle r2 = (Rectangle) rectangles.get(1);
+        assertRectangle(0, 128, 128, 128, r2);
+    }
+    
+    @Test
+    public void testBitmaskSimple() throws ParseException {
+        ROI leftRight = createLeftRightROIGeometry();
+
+        // try an area fully outside
+        int[][] mask = leftRight.getAsBitmask(130, 0, 64, 64, null);
+        assertNull(mask);
+
+        
+        // try an area as big as the ROI
+        mask = leftRight.getAsBitmask(0, 0, 256, 256, null);
+        assertEquals(256, mask.length);
+        for (int i = 0; i < mask.length; i++) {
+            assertEquals(8, mask[i].length);
+            for (int j = 0; j < mask[i].length; j++) {
+                if(j < 4) {
+                    // all ones
+                    assertEquals(-1, mask[i][j]);
+                } else {
+                    // all zeroes
+                    assertEquals(0, mask[i][j]);
+                }
+            }
+        }
+        
+        // a subset of the ROI
+        mask = leftRight.getAsBitmask(64, 64, 128, 128, null);
+        assertEquals(128, mask.length);
+        for (int i = 0; i < mask.length; i++) {
+            assertEquals(4, mask[i].length);
+            for (int j = 0; j < mask[i].length; j++) {
+                if(j < 2) {
+                    // all ones
+                    assertEquals(-1, mask[i][j]);
+                } else {
+                    // all zeroes
+                    assertEquals(0, mask[i][j]);
+                }
+            }
+        }
+        
+    }
+    
+    /**
+     * Returns a ROI based on a binary image, 256x256, white in the left half, black in the right half
+     * @return
+     */
+    ROI createLeftRightROIImage() {
+        // half image ROI, left and right
+        BufferedImage bi = new BufferedImage(256, 256, BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D graphics = bi.createGraphics();
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, 128, 256);
+        graphics.dispose();
+        ROI roiImage = new ROI(bi);
+        return roiImage;
+    }
+
+    /**
+     * Return "bow-tie" shaped polygon ROI, based on a self-intersecting, topologycally invalid polygon,
+     * occupying the top half of the 256x256 space
+     * @return
+     * @throws ParseException
+     */
+    ROIGeometry createBowTieROIGeometry() throws ParseException {
+        Polygon bowtie = (Polygon) new WKTReader().read("POLYGON ((0 0, 256 128, 256 0, 0 128, 0 0))");
+        ROIGeometry roiGeometry = new ROIGeometry(bowtie);
+        return roiGeometry;
+    }
+    
+    /**
+     * A ROIGeometry occupying the top half of the 256x256 area
+     * @return
+     * @throws ParseException
+     */
+    ROIGeometry createTopBottomROIGeometry() throws ParseException {
+        Polygon rectangle = (Polygon) new WKTReader().read("POLYGON ((0 0, 256 0, 256 128, 0 128, 0 0))");
+        ROIGeometry roiGeometry = new ROIGeometry(rectangle);
+        return roiGeometry;
+    }
+    
+    /**
+     * A ROIGeometry occupying the left side of the 256x256 area
+     * @return
+     * @throws ParseException
+     */
+    ROIGeometry createLeftRightROIGeometry() throws ParseException {
+        Polygon rectangle = (Polygon) new WKTReader().read("POLYGON ((0 0, 128 0, 128 256, 0 256, 0 0))");
+        ROIGeometry roiGeometry = new ROIGeometry(rectangle);
+        return roiGeometry;
+    }
+
+    /**
+     * Turns the roi geometry in a ROIShape with the same geometry
+     * @param g
+     * @return
+     */
+    ROIShape getEquivalentROIShape(ROIGeometry g) {
+        // get the roi geometry as shape, this generate a JTS wrapper
+        final Shape shape = g.getAsShape();
+        return new ROIShape(shape);
+    }
+    
+    /**
+     * Checks two ROIs are equivalent
+     * @param first
+     * @param second
+     * @param title
+     * @throws IOException
+     */
+    void assertROIEquivalent(ROI first, ROI second, String title) throws IOException {
+        RenderedImage firstImage = first.getAsImage();
+        RenderedImage secondImage = second.getAsImage();
+        
+        assertImagesEqual(firstImage, secondImage);
+    }
+    
+    private boolean assertReportErrorImagesEqual(ROI first, ROI second) {
+        RenderedImage image1 = first.getAsImage();
+        RenderedImage image2 = second.getAsImage();
+        boolean isOk = true;
+        isOk &= (image1.getWidth() == image2.getWidth());
+        isOk &= (image1.getHeight() == image2.getHeight());
+        double[][] extrema = computeExtrema(image1, image2);
+        for (int band = 0; band < extrema.length; band++) {
+            isOk &= (Math.abs(0d - extrema[0][band]) < 1e-9);
+            isOk &= (Math.abs(0d - extrema[1][band]) < 1e-9);
+        }
+        
+        return isOk;
+    }
+
+    private void printError(ROI first, ROI second) {
+        if (first == null || second == null){
+            System.out.println("A ROI is missing");
+        }
+        if (first instanceof ROIGeometry){
+            printGeometry(((ROIGeometry)first), "ROIGeometry");
+            printRoiShape(((ROIShape)second), "ROIShape");
+        } else {
+            printGeometry(((ROIGeometry)second), "ROIGeometry");
+            printRoiShape(((ROIShape)first), "ROIShape");
+        }
+        
+    }
+    
+    void assertImagesEqual(final RenderedImage image1, final RenderedImage image2) {
+        
+        // Preliminar checks on image properties
+        assertEquals(image1.getWidth(), image2.getWidth());
+        assertEquals(image1.getHeight(), image2.getHeight());
+        
+        // pixel by pixel difference check
+        RenderedImage int1 = FormatDescriptor.create(image1, DataBuffer.TYPE_SHORT, null);
+        RenderedImage int2 = FormatDescriptor.create(image2, DataBuffer.TYPE_SHORT, null);
+        RenderedImage diff = SubtractDescriptor.create(int1, int2, null);
+        RenderedImage extremaImg = ExtremaDescriptor.create(diff, null, 1, 1, false, Integer.MAX_VALUE, null);
+        double[][] extrema = (double[][]) extremaImg.getProperty("extrema");
+        for (int band = 0; band < extrema.length; band++) {
+            assertEquals("Minimum should be 0", 0d, extrema[0][band], 1e-9);
+            assertEquals("Maximum should be 0", 0d, extrema[1][band], 1e-9);
+        }
+    }
+    
+    private double[][] computeExtrema(RenderedImage image1, RenderedImage image2) {
+        RenderedImage int1 = FormatDescriptor.create(image1, DataBuffer.TYPE_SHORT, null);
+        RenderedImage int2 = FormatDescriptor.create(image2, DataBuffer.TYPE_SHORT, null);
+        RenderedImage diff = SubtractDescriptor.create(int1, int2, null);
+        RenderedImage extremaImg = ExtremaDescriptor.create(diff, null, 1, 1, false, Integer.MAX_VALUE, null);
+        double[][] extrema = (double[][]) extremaImg.getProperty("extrema");
+        return extrema;
+    }
+    
+    private void printRoiShape(ROIShape rs1) {
+        PathIterator pt1 = rs1.getAsShape().getPathIterator(null);
+        float [] coords = new float[2];
+        System.out.print("POLYGON ((");
+        while (!pt1.isDone()){
+            pt1.currentSegment(coords);
+            System.out.print(coords[0] + " " + coords[1] + ",");
+            pt1.next();
+        }
+        System.out.println("))/n");
+    }
+    
+    private static void printShape(final Shape shape, final String title) {
+        PathIterator pt1 = shape.getPathIterator(null);
+        double [] coords = new double[2];
+        StringBuilder sb = new StringBuilder();
+        sb.append(title + " POLYGON ((");
+        while (!pt1.isDone()){
+            int type = pt1.currentSegment(coords);
+            
+            sb.append(getPathType(type) + "(" + coords[0] + " " + coords[1] + "),");
+            pt1.next();
+        }
+        final String string = sb.toString();
+        sb = new StringBuilder(string.substring(0, string.length()-1));
+        sb.append("))\n");
+        System.out.println(sb.toString());
+    }
+    
+    private static String getPathType (int pathType){
+        switch (pathType) {
+        case PathIterator.SEG_CLOSE:
+            return "]";
+        case PathIterator.SEG_LINETO:
+            return " ";
+        case PathIterator.SEG_MOVETO:
+            return "[";
+        case PathIterator.SEG_QUADTO:
+            return "QUADTO";
+        case PathIterator.SEG_CUBICTO:
+            return "CUBICTO";
+        }
+        return "UNKNOWN";
+    }
+    
+    private static void printRoiShape(final ROIShape rs1, final String title) {
+        printShape(rs1.getAsShape(), title);
+    }
+    
+    private static void printGeometry(ROIGeometry g, String title) {
+        // System.out.println(title + " " + g.getAsGeometry());
+        printShape(new LiteShape(g.getAsGeometry()), title);
+    }
+    
+    private ROIGeometry createRectROI(double x0, double y0, double x1, double y1) {
+        CoordinateSequence2D cs = new CoordinateSequence2D(
+                x0, y0, x0, y1, x1, y1, x1, y0, x0, y0);
+        
+        Polygon poly = gf.createPolygon(gf.createLinearRing(cs), null);
+        return new ROIGeometry(poly, false);
+    }
+
+    private ROIGeometry createEmptyROI() {
+        Polygon poly = gf.createPolygon(null, null);
+        return new ROIGeometry(poly, false);
+    }
+
+}

--- a/jt-vectorbin/src/test/java/it/geosolutions/jaiext/vectorbin/VectorBinarizeTest.java
+++ b/jt-vectorbin/src/test/java/it/geosolutions/jaiext/vectorbin/VectorBinarizeTest.java
@@ -33,7 +33,7 @@ import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.io.WKTReader;
 
-import org.jaitools.jts.CoordinateSequence2D;
+import it.geosolutions.jaiext.jts.CoordinateSequence2D;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
ROIGeometry class is imported fom JAITools. Fixed the dependency of JAI-EXT jt-scale module to use this ROIGeometry and not the one in JAITools.
This PR depends on the PR "#138 Moving support classes to jt-utilities" ( https://github.com/geosolutions-it/jai-ext/pull/139 ) and it should be merged after.