### PR TITLE
147 - Adding clamp, and nodata check for Bicubic Interpolation

### DIFF
--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleBicubicOpImage.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleBicubicOpImage.java
@@ -710,13 +710,8 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     // Interpolation
                                     s = (int) ((sum + round) >> precisionBits);
                                     sum = 0;
-                                    // Clamp
-                                    if (s > 255) {
-                                        s = 255;
-                                    } else if (s < 0) {
-                                        s = 0;
-                                    }
-
+                                    // Clamp and overshooting fix
+                                    s = clampAndFixOvershootingByte(s, k);
                                     dstData[dstPixelOffset] = (byte) (s & 0xff);
                                 }
                                 // destination pixel offset update
@@ -847,13 +842,8 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                             // Interpolation
                                             s = (int) ((sum + round) >> precisionBits);
 
-                                            // Clamp
-                                            if (s > 255) {
-                                                s = 255;
-                                            } else if (s < 0) {
-                                                s = 0;
-                                            }
-
+                                            // Clamp and overshooting fix
+                                            s = clampAndFixOvershootingByte(s, k);
                                             dstData[dstPixelOffset] = (byte) (s & 0xff);
                                         }
 
@@ -971,13 +961,8 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                             // Interpolation
                                             s = (int) ((sum + round) >> precisionBits);
 
-                                            // Clamp
-                                            if (s > 255) {
-                                                s = 255;
-                                            } else if (s < 0) {
-                                                s = 0;
-                                            }
-
+                                            // Clamp and overshooting fix
+                                            s = clampAndFixOvershootingByte(s, k);
                                             dstData[dstPixelOffset] = (byte) (s & 0xff);
                                         }
 
@@ -1169,13 +1154,8 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                         // Interpolation
                                         s = (int) ((sum + round) >> precisionBits);
 
-                                        // Clamp
-                                        if (s > 65536) {
-                                            s = 65536;
-                                        } else if (s < 0) {
-                                            s = 0;
-                                        }
-
+                                        // Clamp and overshooting fix
+                                        s = clampAndFixOvershootingUShort(s, k);
                                         dstData[dstPixelOffset] = (short) (s & 0xffff);
                                     }
                                 }
@@ -1254,13 +1234,8 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                         // Interpolation
                                         s = (int) ((sum + round) >> precisionBits);
 
-                                        // Clamp
-                                        if (s > 65536) {
-                                            s = 65536;
-                                        } else if (s < 0) {
-                                            s = 0;
-                                        }
-
+                                        // Clamp and overshooting fix
+                                        s = clampAndFixOvershootingUShort(s, k);
                                         dstData[dstPixelOffset] = (short) (s & 0xffff);
                                     }
                                 } else {
@@ -1365,13 +1340,9 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     // Interpolation
                                     s = (int) ((sum + round) >> precisionBits);
                                     sum = 0;
-                                    // Clamp
-                                    if (s > 65536) {
-                                        s = 65536;
-                                    } else if (s < 0) {
-                                        s = 0;
-                                    }
 
+                                    // Clamp and overshooting fix
+                                    s = clampAndFixOvershootingUShort(s, k);
                                     dstData[dstPixelOffset] = (short) (s & 0xffff);
                                 }
                                 // destination pixel offset update
@@ -1489,13 +1460,8 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                             // Interpolation
                                             s = (int) ((sum + round) >> precisionBits);
 
-                                            // Clamp
-                                            if (s > 65536) {
-                                                s = 65536;
-                                            } else if (s < 0) {
-                                                s = 0;
-                                            }
-
+                                            // Clamp and overshooting fix
+                                            s = clampAndFixOvershootingUShort(s, k);
                                             dstData[dstPixelOffset] = (short) (s & 0xffff);
                                         }
 
@@ -1609,13 +1575,8 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                             // Interpolation
                                             s = (int) ((sum + round) >> precisionBits);
 
-                                            // Clamp
-                                            if (s > 65536) {
-                                                s = 65536;
-                                            } else if (s < 0) {
-                                                s = 0;
-                                            }
-
+                                            // Clamp and overshooting fix
+                                            s = clampAndFixOvershootingUShort(s, k);
                                             dstData[dstPixelOffset] = (short) (s & 0xffff);
                                         }
 
@@ -2008,7 +1969,6 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     } else if (s < Short.MIN_VALUE) {
                                         s = Short.MIN_VALUE;
                                     }
-
                                     dstData[dstPixelOffset] = (short) s;
                                 }
                                 // destination pixel offset update
@@ -4315,4 +4275,39 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
 
         return emptyArray;
     }
+
+    private int clampAndFixOvershootingByte(int s, int k) {
+        // Clamp
+        if (s > 255) {
+            s = 255;
+        } else if (s < 0) {
+            s = 0;
+        }
+
+        // Handle corner cases for overshooting 
+        if (destinationNoDataByte[k] == 0 && s == 0) {
+            s = 1;
+        } else if (destinationNoDataByte[k] == 255 && s == 255) {
+            s = 254;
+        }
+        return s;
+    }
+
+    private int clampAndFixOvershootingUShort(int s, int k) {
+        // Clamp
+        if (s > 65535) {
+            s = 65535;
+        } else if (s < 0) {
+            s = 0;
+        }
+
+        // Handle corner cases for overshooting 
+        if (destinationNoDataUShort[k] == 0 && s == 0) {
+            s = 1;
+        } else if (destinationNoDataUShort[k] == 65535 && s == 65535) {
+            s = 65534;
+        }
+        return s;
+    }
+
 }


### PR DESCRIPTION
Clamping on negative values being generated by the cubic interpolation.
Also refine the clamp in case the clamped min or max value matches a common nodata = 0 or nodata = 255.

Tests still need to be added. 
Committing the fix to keep track of the changes.