### PR TITLE
Simple NODATA and ROI awarness for Jiffle

### DIFF
--- a/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/parser/node/TestNodes.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/parser/node/TestNodes.java
@@ -88,7 +88,7 @@ public class TestNodes {
     
     @Test
     public void pixelDefault() throws Exception {
-        assertThat( Pixel.DEFAULT.toString(), is("_x,_y") );
+        assertThat( Pixel.DEFAULT.toString(), is("_x(),_y()") );
     }
     
     @Test
@@ -107,7 +107,7 @@ public class TestNodes {
         FunctionInfo info = getFnInfo(name);
         
         FunctionCall fn = FunctionCall.of(name);
-        assertThat(fn.toString(), is(info.getRuntimeName()));
+        assertThat(fn.toString(), is(info.getRuntimeName() + "()"));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class TestNodes {
     @Test
     public void imageRead() throws Exception {
         Expression e = new GetSourceValue("src", ImagePos.DEFAULT);
-        assertThat(e.toString(), is("readFromImage(src,_x,_y,0)"));
+        assertThat(e.toString(), is("readFromImage(src,_x(),_y(),0)"));
     }
 
     

--- a/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/runtime/RuntimeTestBase.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/runtime/RuntimeTestBase.java
@@ -101,7 +101,7 @@ public abstract class RuntimeTestBase {
         }
     }
     
-    protected RenderedImage createSequenceImage() {
+    protected TiledImage createSequenceImage() {
         TiledImage img = ImageUtilities.createConstantImage(IMG_WIDTH, IMG_WIDTH, 0.0);
         int k = 0;
         for (int y = 0; y < IMG_WIDTH; y++) {
@@ -111,8 +111,18 @@ public abstract class RuntimeTestBase {
         }
         return img;
     }
+
+    protected TiledImage createTriangleImage() {
+        TiledImage img = ImageUtilities.createConstantImage(IMG_WIDTH, IMG_WIDTH, 0.0);
+        for (int y = 0; y < IMG_WIDTH; y++) {
+            for (int x = 0; x < IMG_WIDTH; x++) {
+                img.setSample(x, y, 0, x > y ? 1 : 0);
+            }
+        }
+        return img;
+    }
     
-    protected RenderedImage createRowValueImage() {
+    protected TiledImage createRowValueImage() {
         TiledImage img = ImageUtilities.createConstantImage(IMG_WIDTH, IMG_WIDTH, 0.0);
         for (int y = 0; y < IMG_WIDTH; y++) {
             for (int x = 0; x < IMG_WIDTH; x++) {

--- a/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleOpImage.java
+++ b/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleOpImage.java
@@ -60,6 +60,7 @@ import it.geosolutions.jaiext.jiffle.JiffleException;
 import it.geosolutions.jaiext.jiffle.runtime.BandTransform;
 import it.geosolutions.jaiext.jiffle.runtime.CoordinateTransform;
 import it.geosolutions.jaiext.jiffle.runtime.JiffleIndirectRuntime;
+import it.geosolutions.jaiext.range.NoDataContainer;
 
 /**
  * Jiffle operation.
@@ -137,6 +138,9 @@ public class JiffleOpImage extends OpImage {
         } catch (JiffleException ex) {
             throw new RuntimeException(ex);
         }
+
+        // by default Jiffle does nodata with NaN
+        setProperty(NoDataContainer.GC_NODATA, new NoDataContainer(Double.NaN));
     }
 
     private static Vector specsToImages(


### PR DESCRIPTION
No extra params, just leveraging the input properties and setting the one and only nodata Jiffle actually understands as output (Double.NaN)