### PR TITLE
Various bilinear scale interpolation fixes. backport

### DIFF
--- a/jt-affine/src/test/java/it/geosolutions/jaiext/affine/TestAffine.java
+++ b/jt-affine/src/test/java/it/geosolutions/jaiext/affine/TestAffine.java
@@ -268,7 +268,7 @@ public class TestAffine extends TestBase {
 
                 Raster simpleTile = destinationIMG.getTile(xFirstTile, ySecondTile);
 
-                testEmptyImage(dataType, simpleTile, isBinary);
+                testEmptyImage(dataType, simpleTile, isBinary, interpNear);
 
             }
             // width
@@ -299,7 +299,7 @@ public class TestAffine extends TestBase {
                 int ySecondTile = destinationIMG.getMinTileY() + destinationIMG.getNumYTiles() - 1;
 
                 Raster simpleTile = destinationIMG.getTile(xFirstTile, ySecondTile);
-                testEmptyImage(dataType, simpleTile, isBinary);
+                testEmptyImage(dataType, simpleTile, isBinary, interpNear);
 
             }
             double actualX = destinationIMG.getMinX();
@@ -338,7 +338,7 @@ public class TestAffine extends TestBase {
 
                 Raster simpleTile = destinationIMG.getTile(xFirstTile, ySecondTile);
 
-                testEmptyImage(dataType, simpleTile, isBinary);
+                testEmptyImage(dataType, simpleTile, isBinary, interpNear);
 
             }
             // width
@@ -396,12 +396,13 @@ public class TestAffine extends TestBase {
         }
     }
 
-    protected void testEmptyImage(int dataType, Raster simpleTile, boolean isBinary) {
+    protected void testEmptyImage(int dataType, Raster simpleTile, boolean isBinary, boolean interpNear) {
 
-        int tileminX = simpleTile.getMinX();
-        int tileminY = simpleTile.getMinY();
-        int tileWidth = tileminX + simpleTile.getWidth();
-        int tileHeight = tileminY + simpleTile.getHeight();
+        int padding =  (interpNear ? 0 : 1);
+        int tileminX = simpleTile.getMinX() + padding;
+        int tileminY = simpleTile.getMinY() + padding;
+        int tileWidth = tileminX + simpleTile.getWidth() - padding;
+        int tileHeight = tileminY + simpleTile.getHeight() - padding;
         
         switch (dataType) {
         case DataBuffer.TYPE_BYTE:

--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleBicubicOpImage.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleBicubicOpImage.java
@@ -555,55 +555,52 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
 
                                 // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
                                 // Otherwise it takes the related value.
-                                if (roiBounds.contains(x0, y0)) {
 
-                                    int temp = 0;
-                                    // X offset initialization
-                                    int offsetX = 4 * xfrac[i];
-                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                    // and by 1 on the y axis.
-                                    for (int h = 0; h < 4; h++) {
-                                        for (int z = 0; z < 4; z++) {
-                                            // Selection of one pixel
-                                            pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                    * srcPixelStride + (h - 1) * srcScanlineStride] & 0xff;
-                                            temp += roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) & 0xff;
-                                        }
+                                int temp = 0;
+                                // X offset initialization
+                                int offsetX = 4 * xfrac[i];
+                                // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                // and by 1 on the y axis.
+                                for (int h = 0; h < 4; h++) {
+                                    for (int z = 0; z < 4; z++) {
+                                        // Selection of one pixel
+                                        pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                * srcPixelStride + (h - 1) * srcScanlineStride] & 0xff;
+                                        final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ? 
+                                                roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                        temp += increment & 0xff;
                                     }
-                                    // Control if the 16 pixel are outside the ROI
-                                    if (temp == 0) {
-                                        dstData[dstPixelOffset] = destinationNoDataByte[k];
-                                    } else {
-                                        long sum = 0;
-                                        int s = 0;
-
-                                        for (int h = 0; h < 4; h++) {
-                                            // Row temporary sum initialization
-                                            long tempSum = 0;
-                                            for (int z = 0; z < 4; z++) {
-                                                // Update of the temporary sum
-                                                tempSum += (pixelKernel[h][z] * dataHi[offsetX + z]);
-                                            }
-                                            // Vertical sum update
-                                            sum += ((tempSum + round) >> precisionBits)
-                                                    * dataVi[offsetY + h];
-                                        }
-                                        // Interpolation
-                                        s = (int) ((sum + round) >> precisionBits);
-
-                                        // Clamp
-                                        if (s > 255) {
-                                            s = 255;
-                                        } else if (s < 0) {
-                                            s = 0;
-                                        }
-
-                                        dstData[dstPixelOffset] = (byte) (s & 0xff);
-                                    }
-                                } else {
-                                    // The destination no data value is saved in the destination array
+                                }
+                                // Control if the 16 pixel are outside the ROI
+                                if (temp == 0) {
                                     dstData[dstPixelOffset] = destinationNoDataByte[k];
+                                } else {
+                                    long sum = 0;
+                                    int s = 0;
+
+                                    for (int h = 0; h < 4; h++) {
+                                        // Row temporary sum initialization
+                                        long tempSum = 0;
+                                        for (int z = 0; z < 4; z++) {
+                                            // Update of the temporary sum
+                                            tempSum += (pixelKernel[h][z] * dataHi[offsetX + z]);
+                                        }
+                                        // Vertical sum update
+                                        sum += ((tempSum + round) >> precisionBits)
+                                                * dataVi[offsetY + h];
+                                    }
+                                    // Interpolation
+                                    s = (int) ((sum + round) >> precisionBits);
+
+                                    // Clamp
+                                    if (s > 255) {
+                                        s = 255;
+                                    } else if (s < 0) {
+                                        s = 0;
+                                    }
+
+                                    dstData[dstPixelOffset] = (byte) (s & 0xff);
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -893,85 +890,80 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     int x0 = src.getX() + posx / srcPixelStride;
                                     int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int pos = posx + posy;
 
-                                        int pos = posx + posy;
+                                    // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
+                                    // Otherwise it takes the related value.
 
-                                        // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
-                                        // Otherwise it takes the related value.
+                                    // int tempND = 0;
+                                    int tempROI = 0;
+                                    // X offset initialization
+                                    int offsetX = 4 * xfrac[i];
+                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                    // and by roiscanlinestride on the y axis.
+                                    for (int h = 0; h < 4; h++) {
+                                        for (int z = 0; z < 4; z++) {
+                                            // Selection of one pixel
+                                            pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                    * srcPixelStride + (h - 1)
+                                                    * srcScanlineStride] & 0xff;
 
-                                        // int tempND = 0;
-                                        int tempROI = 0;
-                                        // X offset initialization
-                                        int offsetX = 4 * xfrac[i];
-                                        // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                        // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                        // and by roiscanlinestride on the y axis.
-                                        for (int h = 0; h < 4; h++) {
-                                            for (int z = 0; z < 4; z++) {
-                                                // Selection of one pixel
-                                                pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                        * srcPixelStride + (h - 1)
-                                                        * srcScanlineStride] & 0xff;
+                                            final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                    roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                            tempROI += increment & 0xff;
 
-                                                tempROI += roiIter.getSample(x0 + h - 1,
-                                                        y0 + z - 1, 0) & 0xff;
-
-                                                if (byteLookupTable[k][(int) pixelKernel[h][z]] != destinationNoDataByte[k]) {
-                                                    weight |= (0x01 << (4 * h + z));
-                                                } else {
-                                                    weight &= (0xffff - (0x01 << 4 * h + z));
-                                                }
+                                            if (byteLookupTable[k][(int) pixelKernel[h][z]] != destinationNoDataByte[k]) {
+                                                weight |= (0x01 << (4 * h + z));
+                                            } else {
+                                                weight &= (0xffff - (0x01 << 4 * h + z));
                                             }
                                         }
+                                    }
 
-                                        // Control if the 16 pixel are outside the ROI
-                                        if (weight == 0 || tempROI == 0) {
-                                            dstData[dstPixelOffset] = destinationNoDataByte[k];
-                                        } else {
-
-                                            long sum = 0;
-                                            int s = 0;
-
-                                            for (int h = 0; h < 4; h++) {
-                                                // Row temporary sum initialization
-                                                long tempSum = 0;
-                                                temp = (byte) ((weight >> 4 * h) & 0x0F);
-                                                long[] tempData = bicubicInpainting(pixelKernel[h],
-                                                        temp, emptyArray);
-                                                for (int z = 0; z < 4; z++) {
-                                                    // Update of the temporary sum
-                                                    tempSum += (tempData[z] * dataHi[offsetX + z]);
-                                                }
-                                                if (temp > 0) {
-                                                    weightVert |= (0x01 << h);
-                                                } else {
-                                                    weightVert &= (0x0F - (0x01 << h));
-                                                }
-                                                sumArray[h] = ((tempSum + round) >> precisionBits);
-                                            }
-
-                                            long[] tempData = bicubicInpainting(sumArray,
-                                                    weightVert, emptyArray);
-                                            // weight reset
-                                            weight = 0;
-                                            weightVert = 0;
-                                            // Vertical sum update
-                                            for (int h = 0; h < 4; h++) {
-                                                // Update of the temporary sum
-                                                sum += tempData[h] * dataVi[offsetY + h];
-                                            }
-
-                                            // Interpolation
-                                            s = (int) ((sum + round) >> precisionBits);
-
-                                            // Clamp and overshooting fix
-                                            s = InterpolationBicubic.clampAndFixOvershootingByte(s, destinationNoDataByte[k]);
-                                            dstData[dstPixelOffset] = (byte) (s & 0xff);
-                                        }
-
-                                    } else {
+                                    // Control if the 16 pixel are outside the ROI
+                                    if (weight == 0 || tempROI == 0) {
                                         dstData[dstPixelOffset] = destinationNoDataByte[k];
+                                    } else {
+
+                                        long sum = 0;
+                                        int s = 0;
+
+                                        for (int h = 0; h < 4; h++) {
+                                            // Row temporary sum initialization
+                                            long tempSum = 0;
+                                            temp = (byte) ((weight >> 4 * h) & 0x0F);
+                                            long[] tempData = bicubicInpainting(pixelKernel[h],
+                                                    temp, emptyArray);
+                                            for (int z = 0; z < 4; z++) {
+                                                // Update of the temporary sum
+                                                tempSum += (tempData[z] * dataHi[offsetX + z]);
+                                            }
+                                            if (temp > 0) {
+                                                weightVert |= (0x01 << h);
+                                            } else {
+                                                weightVert &= (0x0F - (0x01 << h));
+                                            }
+                                            sumArray[h] = ((tempSum + round) >> precisionBits);
+                                        }
+
+                                        long[] tempData = bicubicInpainting(sumArray,
+                                                weightVert, emptyArray);
+                                        // weight reset
+                                        weight = 0;
+                                        weightVert = 0;
+                                        // Vertical sum update
+                                        for (int h = 0; h < 4; h++) {
+                                            // Update of the temporary sum
+                                            sum += tempData[h] * dataVi[offsetY + h];
+                                        }
+
+                                        // Interpolation
+                                        s = (int) ((sum + round) >> precisionBits);
+
+                                        // Clamp and overshooting fix
+                                        s = InterpolationBicubic.clampAndFixOvershootingByte(s, destinationNoDataByte[k]);
+                                        dstData[dstPixelOffset] = (byte) (s & 0xff);
                                     }
 
                                     // destination pixel offset update
@@ -1201,50 +1193,47 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
 
                                 // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
                                 // Otherwise it takes the related value.
-                                if (roiBounds.contains(x0, y0)) {
+                                int temp = 0;
+                                // X offset initialization
+                                int offsetX = 4 * xfrac[i];
+                                // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                // and by roiscanlinestride on the y axis.
+                                for (int h = 0; h < 4; h++) {
+                                    for (int z = 0; z < 4; z++) {
+                                        // Selection of one pixel
+                                        pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                * srcPixelStride + (h - 1) * srcScanlineStride] & 0xffff;
+                                        final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
 
-                                    int temp = 0;
-                                    // X offset initialization
-                                    int offsetX = 4 * xfrac[i];
-                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                    // and by roiscanlinestride on the y axis.
-                                    for (int h = 0; h < 4; h++) {
-                                        for (int z = 0; z < 4; z++) {
-                                            // Selection of one pixel
-                                            pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                    * srcPixelStride + (h - 1) * srcScanlineStride] & 0xffff;
-                                            temp += roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) & 0xffff;
-                                        }
+                                        temp += increment & 0xffff;
                                     }
-                                    // Control if the 16 pixel are outside the ROI
-                                    if (temp == 0) {
-                                        dstData[dstPixelOffset] = destinationNoDataUShort[k];
-                                    } else {
-                                        long sum = 0;
-                                        int s = 0;
-
-                                        for (int h = 0; h < 4; h++) {
-                                            // Row temporary sum initialization
-                                            long tempSum = 0;
-                                            for (int z = 0; z < 4; z++) {
-                                                // Update of the temporary sum
-                                                tempSum += (pixelKernel[h][z] * dataHi[offsetX + z]);
-                                            }
-                                            // Vertical sum update
-                                            sum += ((tempSum + round) >> precisionBits)
-                                                    * dataVi[offsetY + h];
-                                        }
-                                        // Interpolation
-                                        s = (int) ((sum + round) >> precisionBits);
-
-                                        // Clamp and overshooting fix
-                                        s = InterpolationBicubic.clampAndFixOvershootingUShort(s, destinationNoDataUShort[k]);
-                                        dstData[dstPixelOffset] = (short) (s & 0xffff);
-                                    }
-                                } else {
-                                    // The destination no data value is saved in the destination array
+                                }
+                                // Control if the 16 pixel are outside the ROI
+                                if (temp == 0) {
                                     dstData[dstPixelOffset] = destinationNoDataUShort[k];
+                                } else {
+                                    long sum = 0;
+                                    int s = 0;
+
+                                    for (int h = 0; h < 4; h++) {
+                                        // Row temporary sum initialization
+                                        long tempSum = 0;
+                                        for (int z = 0; z < 4; z++) {
+                                            // Update of the temporary sum
+                                            tempSum += (pixelKernel[h][z] * dataHi[offsetX + z]);
+                                        }
+                                        // Vertical sum update
+                                        sum += ((tempSum + round) >> precisionBits)
+                                                * dataVi[offsetY + h];
+                                    }
+                                    // Interpolation
+                                    s = (int) ((sum + round) >> precisionBits);
+
+                                    // Clamp and overshooting fix
+                                    s = InterpolationBicubic.clampAndFixOvershootingUShort(s, destinationNoDataUShort[k]);
+                                    dstData[dstPixelOffset] = (short) (s & 0xffff);
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -1509,83 +1498,77 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     int x0 = src.getX() + posx / srcPixelStride;
                                     int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int pos = posx + posy;
 
-                                        int pos = posx + posy;
+                                    // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
+                                    // Otherwise it takes the related value.
 
-                                        // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
-                                        // Otherwise it takes the related value.
+                                    int tempROI = 0;
+                                    // X offset initialization
+                                    int offsetX = 4 * xfrac[i];
+                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                    // and by roiscanlinestride on the y axis.
+                                    for (int h = 0; h < 4; h++) {
+                                        for (int z = 0; z < 4; z++) {
+                                            // Selection of one pixel
+                                            pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                    * srcPixelStride + (h - 1)
+                                                    * srcScanlineStride] & 0xffff;
+                                            final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                    roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                            tempROI += increment & 0xffff;
 
-                                        int tempROI = 0;
-                                        // X offset initialization
-                                        int offsetX = 4 * xfrac[i];
-                                        // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                        // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                        // and by roiscanlinestride on the y axis.
-                                        for (int h = 0; h < 4; h++) {
-                                            for (int z = 0; z < 4; z++) {
-                                                // Selection of one pixel
-                                                pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                        * srcPixelStride + (h - 1)
-                                                        * srcScanlineStride] & 0xffff;
-
-                                                tempROI += roiIter.getSample(x0 + h - 1,
-                                                        y0 + z - 1, 0) & 0xffff;
-
-                                                if (!noData.contains((short) pixelKernel[h][z])) {
-                                                    weight |= (0x01 << (4 * h + z));
-                                                } else {
-                                                    weight &= (0xffff - (0x01 << 4 * h + z));
-                                                }
+                                            if (!noData.contains((short) pixelKernel[h][z])) {
+                                                weight |= (0x01 << (4 * h + z));
+                                            } else {
+                                                weight &= (0xffff - (0x01 << 4 * h + z));
                                             }
                                         }
+                                    }
 
-                                        // Control if the 16 pixel are outside the ROI
-                                        if (weight == 0 || tempROI == 0) {
-                                            dstData[dstPixelOffset] = destinationNoDataUShort[k];
-                                        } else {
-
-                                            long sum = 0;
-                                            int s = 0;
-
-                                            for (int h = 0; h < 4; h++) {
-                                                // Row temporary sum initialization
-                                                long tempSum = 0;
-                                                temp = (byte) ((weight >> 4 * h) & 0x0F);
-                                                long[] tempData = bicubicInpainting(pixelKernel[h],
-                                                        temp, emptyArray);
-                                                for (int z = 0; z < 4; z++) {
-                                                    // Update of the temporary sum
-                                                    tempSum += (tempData[z] * dataHi[offsetX + z]);
-                                                }
-                                                if (temp > 0) {
-                                                    weightVert |= (0x01 << h);
-                                                } else {
-                                                    weightVert &= (0x0F - (0x01 << h));
-                                                }
-                                                sumArray[h] = ((tempSum + round) >> precisionBits);
-                                            }
-
-                                            long[] tempData = bicubicInpainting(sumArray,
-                                                    weightVert, emptyArray);
-                                            weight = 0;
-                                            weightVert = 0;
-                                            // Vertical sum update
-                                            for (int h = 0; h < 4; h++) {
-                                                // Update of the temporary sum
-                                                sum += tempData[h] * dataVi[offsetY + h];
-                                            }
-
-                                            // Interpolation
-                                            s = (int) ((sum + round) >> precisionBits);
-
-                                            // Clamp and overshooting fix
-                                            s = InterpolationBicubic.clampAndFixOvershootingUShort(s, destinationNoDataUShort[k]);
-                                            dstData[dstPixelOffset] = (short) (s & 0xffff);
-                                        }
-
-                                    } else {
+                                    // Control if the 16 pixel are outside the ROI
+                                    if (weight == 0 || tempROI == 0) {
                                         dstData[dstPixelOffset] = destinationNoDataUShort[k];
+                                    } else {
+
+                                        long sum = 0;
+                                        int s = 0;
+
+                                        for (int h = 0; h < 4; h++) {
+                                            // Row temporary sum initialization
+                                            long tempSum = 0;
+                                            temp = (byte) ((weight >> 4 * h) & 0x0F);
+                                            long[] tempData = bicubicInpainting(pixelKernel[h],
+                                                    temp, emptyArray);
+                                            for (int z = 0; z < 4; z++) {
+                                                // Update of the temporary sum
+                                                tempSum += (tempData[z] * dataHi[offsetX + z]);
+                                            }
+                                            if (temp > 0) {
+                                                weightVert |= (0x01 << h);
+                                            } else {
+                                                weightVert &= (0x0F - (0x01 << h));
+                                            }
+                                            sumArray[h] = ((tempSum + round) >> precisionBits);
+                                        }
+
+                                        long[] tempData = bicubicInpainting(sumArray,
+                                                weightVert, emptyArray);
+                                        weight = 0;
+                                        weightVert = 0;
+                                        // Vertical sum update
+                                        for (int h = 0; h < 4; h++) {
+                                            // Update of the temporary sum
+                                            sum += tempData[h] * dataVi[offsetY + h];
+                                        }
+
+                                        // Interpolation
+                                        s = (int) ((sum + round) >> precisionBits);
+
+                                        // Clamp and overshooting fix
+                                        s = InterpolationBicubic.clampAndFixOvershootingUShort(s, destinationNoDataUShort[k]);
+                                        dstData[dstPixelOffset] = (short) (s & 0xffff);
                                     }
 
                                     // destination pixel offset update
@@ -1819,55 +1802,51 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
 
                                 // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
                                 // Otherwise it takes the related value.
-                                if (roiBounds.contains(x0, y0)) {
-
-                                    int temp = 0;
-                                    // X offset initialization
-                                    int offsetX = 4 * xfrac[i];
-                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                    // and by roiscanlinestride on the y axis.
-                                    for (int h = 0; h < 4; h++) {
-                                        for (int z = 0; z < 4; z++) {
-                                            // Selection of one pixel
-                                            pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                    * srcPixelStride + (h - 1) * srcScanlineStride];
-                                            temp += roiIter.getSample(x0 + h - 1, y0 + z - 1, 0);
-                                        }
+                                int temp = 0;
+                                // X offset initialization
+                                int offsetX = 4 * xfrac[i];
+                                // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                // and by roiscanlinestride on the y axis.
+                                for (int h = 0; h < 4; h++) {
+                                    for (int z = 0; z < 4; z++) {
+                                        // Selection of one pixel
+                                        pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                * srcPixelStride + (h - 1) * srcScanlineStride];
+                                        final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                        temp += increment & 0xffff;
                                     }
-                                    // Control if the 16 pixel are outside the ROI
-                                    if (temp == 0) {
-                                        dstData[dstPixelOffset] = destinationNoDataShort[k];
-                                    } else {
-                                        long sum = 0;
-                                        int s = 0;
-
-                                        for (int h = 0; h < 4; h++) {
-                                            // Row temporary sum initialization
-                                            long tempSum = 0;
-                                            for (int z = 0; z < 4; z++) {
-                                                // Update of the temporary sum
-                                                tempSum += (pixelKernel[h][z] * dataHi[offsetX + z]);
-                                            }
-                                            // Vertical sum update
-                                            sum += ((tempSum + round) >> precisionBits)
-                                                    * dataVi[offsetY + h];
-                                        }
-                                        // Interpolation
-                                        s = (int) ((sum + round) >> precisionBits);
-
-                                        // Clamp
-                                        if (s > Short.MAX_VALUE) {
-                                            s = Short.MAX_VALUE;
-                                        } else if (s < Short.MIN_VALUE) {
-                                            s = Short.MIN_VALUE;
-                                        }
-
-                                        dstData[dstPixelOffset] = (short) s;
-                                    }
-                                } else {
-                                    // The destination no data value is saved in the destination array
+                                }
+                                // Control if the 16 pixel are outside the ROI
+                                if (temp == 0) {
                                     dstData[dstPixelOffset] = destinationNoDataShort[k];
+                                } else {
+                                    long sum = 0;
+                                    int s = 0;
+
+                                    for (int h = 0; h < 4; h++) {
+                                        // Row temporary sum initialization
+                                        long tempSum = 0;
+                                        for (int z = 0; z < 4; z++) {
+                                            // Update of the temporary sum
+                                            tempSum += (pixelKernel[h][z] * dataHi[offsetX + z]);
+                                        }
+                                        // Vertical sum update
+                                        sum += ((tempSum + round) >> precisionBits)
+                                                * dataVi[offsetY + h];
+                                    }
+                                    // Interpolation
+                                    s = (int) ((sum + round) >> precisionBits);
+
+                                    // Clamp
+                                    if (s > Short.MAX_VALUE) {
+                                        s = Short.MAX_VALUE;
+                                    } else if (s < Short.MIN_VALUE) {
+                                        s = Short.MIN_VALUE;
+                                    }
+
+                                    dstData[dstPixelOffset] = (short) s;
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -2140,87 +2119,82 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     int x0 = src.getX() + posx / srcPixelStride;
                                     int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int pos = posx + posy;
 
-                                        int pos = posx + posy;
+                                    // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
+                                    // Otherwise it takes the related value.
+                                    int tempROI = 0;
+                                    // X offset initialization
+                                    int offsetX = 4 * xfrac[i];
+                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                    // and by roiscanlinestride on the y axis.
+                                    for (int h = 0; h < 4; h++) {
+                                        for (int z = 0; z < 4; z++) {
+                                            // Selection of one pixel
+                                            pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                    * srcPixelStride + (h - 1)
+                                                    * srcScanlineStride];
 
-                                        // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
-                                        // Otherwise it takes the related value.
-                                        int tempROI = 0;
-                                        // X offset initialization
-                                        int offsetX = 4 * xfrac[i];
-                                        // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                        // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                        // and by roiscanlinestride on the y axis.
-                                        for (int h = 0; h < 4; h++) {
-                                            for (int z = 0; z < 4; z++) {
-                                                // Selection of one pixel
-                                                pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                        * srcPixelStride + (h - 1)
-                                                        * srcScanlineStride];
+                                            final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                    roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                            tempROI += increment;
 
-                                                tempROI += roiIter.getSample(x0 + h - 1,
-                                                        y0 + z - 1, 0);
-
-                                                if (!noData.contains((short) pixelKernel[h][z])) {
-                                                    weight |= (0x01 << (4 * h + z));
-                                                } else {
-                                                    weight &= (0xffff - (0x01 << 4 * h + z));
-                                                }
+                                            if (!noData.contains((short) pixelKernel[h][z])) {
+                                                weight |= (0x01 << (4 * h + z));
+                                            } else {
+                                                weight &= (0xffff - (0x01 << 4 * h + z));
                                             }
                                         }
+                                    }
 
-                                        // Control if the 16 pixel are outside the ROI
-                                        if (weight == 0 || tempROI == 0) {
-                                            dstData[dstPixelOffset] = destinationNoDataShort[k];
-                                        } else {
-
-                                            long sum = 0;
-                                            int s = 0;
-
-                                            for (int h = 0; h < 4; h++) {
-                                                // Row temporary sum initialization
-                                                long tempSum = 0;
-                                                temp = (byte) ((weight >> 4 * h) & 0x0F);
-                                                long[] tempData = bicubicInpainting(pixelKernel[h],
-                                                        temp, emptyArray);
-                                                for (int z = 0; z < 4; z++) {
-                                                    // Update of the temporary sum
-                                                    tempSum += (tempData[z] * dataHi[offsetX + z]);
-                                                }
-                                                if (temp > 0) {
-                                                    weightVert |= (0x01 << h);
-                                                } else {
-                                                    weightVert &= (0x0F - (0x01 << h));
-                                                }
-                                                sumArray[h] = ((tempSum + round) >> precisionBits);
-                                            }
-
-                                            long[] tempData = bicubicInpainting(sumArray,
-                                                    weightVert, emptyArray);
-                                            weight = 0;
-                                            weightVert = 0;
-                                            // Vertical sum update
-                                            for (int h = 0; h < 4; h++) {
-                                                // Update of the temporary sum
-                                                sum += tempData[h] * dataVi[offsetY + h];
-                                            }
-
-                                            // Interpolation
-                                            s = (int) ((sum + round) >> precisionBits);
-
-                                            // Clamp
-                                            if (s > Short.MAX_VALUE) {
-                                                s = Short.MAX_VALUE;
-                                            } else if (s < Short.MIN_VALUE) {
-                                                s = Short.MIN_VALUE;
-                                            }
-
-                                            dstData[dstPixelOffset] = (short) s;
-                                        }
-
-                                    } else {
+                                    // Control if the 16 pixel are outside the ROI
+                                    if (weight == 0 || tempROI == 0) {
                                         dstData[dstPixelOffset] = destinationNoDataShort[k];
+                                    } else {
+
+                                        long sum = 0;
+                                        int s = 0;
+
+                                        for (int h = 0; h < 4; h++) {
+                                            // Row temporary sum initialization
+                                            long tempSum = 0;
+                                            temp = (byte) ((weight >> 4 * h) & 0x0F);
+                                            long[] tempData = bicubicInpainting(pixelKernel[h],
+                                                    temp, emptyArray);
+                                            for (int z = 0; z < 4; z++) {
+                                                // Update of the temporary sum
+                                                tempSum += (tempData[z] * dataHi[offsetX + z]);
+                                            }
+                                            if (temp > 0) {
+                                                weightVert |= (0x01 << h);
+                                            } else {
+                                                weightVert &= (0x0F - (0x01 << h));
+                                            }
+                                            sumArray[h] = ((tempSum + round) >> precisionBits);
+                                        }
+
+                                        long[] tempData = bicubicInpainting(sumArray,
+                                                weightVert, emptyArray);
+                                        weight = 0;
+                                        weightVert = 0;
+                                        // Vertical sum update
+                                        for (int h = 0; h < 4; h++) {
+                                            // Update of the temporary sum
+                                            sum += tempData[h] * dataVi[offsetY + h];
+                                        }
+
+                                        // Interpolation
+                                        s = (int) ((sum + round) >> precisionBits);
+
+                                        // Clamp
+                                        if (s > Short.MAX_VALUE) {
+                                            s = Short.MAX_VALUE;
+                                        } else if (s < Short.MIN_VALUE) {
+                                            s = Short.MIN_VALUE;
+                                        }
+
+                                        dstData[dstPixelOffset] = (short) s;
                                     }
 
                                     // destination pixel offset update
@@ -2440,48 +2414,44 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
 
                                 // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
                                 // Otherwise it takes the related value.
-                                if (roiBounds.contains(x0, y0)) {
-
-                                    int temp = 0;
-                                    // X offset initialization
-                                    int offsetX = 4 * xfrac[i];
-                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                    // and by roiscanlinestride on the y axis.
-                                    for (int h = 0; h < 4; h++) {
-                                        for (int z = 0; z < 4; z++) {
-                                            // Selection of one pixel
-                                            pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                    * srcPixelStride + (h - 1) * srcScanlineStride];
-                                            temp += roiIter.getSample(x0 + h - 1, y0 + z - 1, 0);
-                                        }
+                                int temp = 0;
+                                // X offset initialization
+                                int offsetX = 4 * xfrac[i];
+                                // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                // and by roiscanlinestride on the y axis.
+                                for (int h = 0; h < 4; h++) {
+                                    for (int z = 0; z < 4; z++) {
+                                        // Selection of one pixel
+                                        pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                * srcPixelStride + (h - 1) * srcScanlineStride];
+                                        final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                        temp += increment;
                                     }
-                                    // Control if the 16 pixel are outside the ROI
-                                    if (temp == 0) {
-                                        dstData[dstPixelOffset] = destinationNoDataInt[k];
-                                    } else {
-                                        long sum = 0;
-                                        int s = 0;
-
-                                        for (int h = 0; h < 4; h++) {
-                                            // Row temporary sum initialization
-                                            long tempSum = 0;
-                                            for (int z = 0; z < 4; z++) {
-                                                // Update of the temporary sum
-                                                tempSum += (pixelKernel[h][z] * dataHi[offsetX + z]);
-                                            }
-                                            // Vertical sum update
-                                            sum += ((tempSum + round) >> precisionBits)
-                                                    * dataVi[offsetY + h];
-                                        }
-                                        // Interpolation
-                                        s = (int) ((sum + round) >> precisionBits);
-
-                                        dstData[dstPixelOffset] = s;
-                                    }
-                                } else {
-                                    // The destination no data value is saved in the destination array
+                                }
+                                // Control if the 16 pixel are outside the ROI
+                                if (temp == 0) {
                                     dstData[dstPixelOffset] = destinationNoDataInt[k];
+                                } else {
+                                    long sum = 0;
+                                    int s = 0;
+
+                                    for (int h = 0; h < 4; h++) {
+                                        // Row temporary sum initialization
+                                        long tempSum = 0;
+                                        for (int z = 0; z < 4; z++) {
+                                            // Update of the temporary sum
+                                            tempSum += (pixelKernel[h][z] * dataHi[offsetX + z]);
+                                        }
+                                        // Vertical sum update
+                                        sum += ((tempSum + round) >> precisionBits)
+                                                * dataVi[offsetY + h];
+                                    }
+                                    // Interpolation
+                                    s = (int) ((sum + round) >> precisionBits);
+
+                                    dstData[dstPixelOffset] = s;
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -2743,82 +2713,75 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     int x0 = src.getX() + posx / srcPixelStride;
                                     int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int pos = posx + posy;
 
-                                        int pos = posx + posy;
+                                    // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
+                                    // Otherwise it takes the related value.
+                                    int tempROI = 0;
+                                    // X offset initialization
+                                    int offsetX = 4 * xfrac[i];
+                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                    // and by roiscanlinestride on the y axis.
+                                    for (int h = 0; h < 4; h++) {
+                                        for (int z = 0; z < 4; z++) {
+                                            // Selection of one pixel
+                                            pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                    * srcPixelStride + (h - 1)
+                                                    * srcScanlineStride];
+                                            final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                    roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                            tempROI += increment;
 
-                                        // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
-                                        // Otherwise it takes the related value.
-                                        int tempROI = 0;
-                                        // X offset initialization
-                                        int offsetX = 4 * xfrac[i];
-                                        // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                        // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                        // and by roiscanlinestride on the y axis.
-                                        for (int h = 0; h < 4; h++) {
-                                            for (int z = 0; z < 4; z++) {
-                                                // Selection of one pixel
-                                                pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                        * srcPixelStride + (h - 1)
-                                                        * srcScanlineStride];
-
-                                                tempROI += roiIter.getSample(x0 + h - 1,
-                                                        y0 + z - 1, 0);
-
-                                                if (!noData.contains((int) pixelKernel[h][z])) {
-                                                    weight |= (0x01 << (4 * h + z));
-                                                } else {
-                                                    weight &= (0xffff - (0x01 << 4 * h + z));
-                                                }
+                                            if (!noData.contains((int) pixelKernel[h][z])) {
+                                                weight |= (0x01 << (4 * h + z));
+                                            } else {
+                                                weight &= (0xffff - (0x01 << 4 * h + z));
                                             }
                                         }
-
-                                        // Control if the 16 pixel are outside the ROI
-                                        if (weight == 0 || tempROI == 0) {
-                                            dstData[dstPixelOffset] = destinationNoDataInt[k];
-                                        } else {
-
-                                            long sum = 0;
-                                            int s = 0;
-
-                                            for (int h = 0; h < 4; h++) {
-                                                // Row temporary sum initialization
-                                                long tempSum = 0;
-                                                temp = (byte) ((weight >> 4 * h) & 0x0F);
-                                                long[] tempData = bicubicInpainting(pixelKernel[h],
-                                                        temp, emptyArray);
-                                                for (int z = 0; z < 4; z++) {
-                                                    // Update of the temporary sum
-                                                    tempSum += (tempData[z] * dataHi[offsetX + z]);
-                                                }
-                                                if (temp > 0) {
-                                                    weightVert |= (0x01 << h);
-                                                } else {
-                                                    weightVert &= (0x0F - (0x01 << h));
-                                                }
-                                                sumArray[h] = ((tempSum + round) >> precisionBits);
-                                            }
-
-                                            long[] tempData = bicubicInpainting(sumArray,
-                                                    weightVert, emptyArray);
-                                            weight = 0;
-                                            weightVert = 0;
-                                            // Vertical sum update
-                                            for (int h = 0; h < 4; h++) {
-                                                // Update of the temporary sum
-                                                sum += tempData[h] * dataVi[offsetY + h];
-                                            }
-
-                                            // Interpolation
-                                            s = (int) ((sum + round) >> precisionBits);
-
-                                            dstData[dstPixelOffset] = s;
-                                        }
-
-                                    } else {
-                                        dstData[dstPixelOffset] = destinationNoDataInt[k];
                                     }
 
+                                    // Control if the 16 pixel are outside the ROI
+                                    if (weight == 0 || tempROI == 0) {
+                                        dstData[dstPixelOffset] = destinationNoDataInt[k];
+                                    } else {
+
+                                        long sum = 0;
+                                        int s = 0;
+
+                                        for (int h = 0; h < 4; h++) {
+                                            // Row temporary sum initialization
+                                            long tempSum = 0;
+                                            temp = (byte) ((weight >> 4 * h) & 0x0F);
+                                            long[] tempData = bicubicInpainting(pixelKernel[h],
+                                                    temp, emptyArray);
+                                            for (int z = 0; z < 4; z++) {
+                                                // Update of the temporary sum
+                                                tempSum += (tempData[z] * dataHi[offsetX + z]);
+                                            }
+                                            if (temp > 0) {
+                                                weightVert |= (0x01 << h);
+                                            } else {
+                                                weightVert &= (0x0F - (0x01 << h));
+                                            }
+                                            sumArray[h] = ((tempSum + round) >> precisionBits);
+                                        }
+
+                                        long[] tempData = bicubicInpainting(sumArray,
+                                                weightVert, emptyArray);
+                                        weight = 0;
+                                        weightVert = 0;
+                                        // Vertical sum update
+                                        for (int h = 0; h < 4; h++) {
+                                            // Update of the temporary sum
+                                            sum += tempData[h] * dataVi[offsetY + h];
+                                        }
+
+                                        // Interpolation
+                                        s = (int) ((sum + round) >> precisionBits);
+
+                                        dstData[dstPixelOffset] = s;
+                                    }
                                     // destination pixel offset update
                                     dstPixelOffset += dstPixelStride;
                                 }
@@ -3043,52 +3006,48 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
 
                                 // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
                                 // Otherwise it takes the related value.
-                                if (roiBounds.contains(x0, y0)) {
-
-                                    int temp = 0;
-                                    // X offset initialization
-                                    int offsetX = 4 * xfrac[i];
-                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                    // and by roiscanlinestride on the y axis.
-                                    for (int h = 0; h < 4; h++) {
-                                        for (int z = 0; z < 4; z++) {
-                                            // Selection of one pixel
-                                            pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                    * srcPixelStride + (h - 1) * srcScanlineStride];
-                                            temp += roiIter.getSample(x0 + h - 1, y0 + z - 1, 0);
-                                        }
+                                int temp = 0;
+                                // X offset initialization
+                                int offsetX = 4 * xfrac[i];
+                                // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                // and by roiscanlinestride on the y axis.
+                                for (int h = 0; h < 4; h++) {
+                                    for (int z = 0; z < 4; z++) {
+                                        // Selection of one pixel
+                                        pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                * srcPixelStride + (h - 1) * srcScanlineStride];
+                                        final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                        temp += increment;
                                     }
-                                    // Control if the 16 pixel are outside the ROI
-                                    if (temp == 0) {
-                                        dstData[dstPixelOffset] = destinationNoDataFloat[k];
-                                    } else {
-                                        double sum = 0;
-
-                                        for (int h = 0; h < 4; h++) {
-                                            // Row temporary sum initialization
-                                            double tempSum = 0;
-                                            for (int z = 0; z < 4; z++) {
-                                                // Update of the temporary sum
-                                                tempSum += (pixelKernel[h][z] * dataHf[offsetX + z]);
-                                            }
-                                            // Vertical sum update
-                                            sum += tempSum * dataVf[offsetY + h];
-                                        }
-
-                                        // Clamp
-                                        if (sum > Float.MAX_VALUE) {
-                                            sum = Float.MAX_VALUE;
-                                        } else if (sum < -Float.MAX_VALUE) {
-                                            sum = -Float.MAX_VALUE;
-                                        }
-
-                                        // The interpolated value is saved in the destination array
-                                        dstData[dstPixelOffset] = (float) sum;
-                                    }
-                                } else {
-                                    // The destination no data value is saved in the destination array
+                                }
+                                // Control if the 16 pixel are outside the ROI
+                                if (temp == 0) {
                                     dstData[dstPixelOffset] = destinationNoDataFloat[k];
+                                } else {
+                                    double sum = 0;
+
+                                    for (int h = 0; h < 4; h++) {
+                                        // Row temporary sum initialization
+                                        double tempSum = 0;
+                                        for (int z = 0; z < 4; z++) {
+                                            // Update of the temporary sum
+                                            tempSum += (pixelKernel[h][z] * dataHf[offsetX + z]);
+                                        }
+                                        // Vertical sum update
+                                        sum += tempSum * dataVf[offsetY + h];
+                                    }
+
+                                    // Clamp
+                                    if (sum > Float.MAX_VALUE) {
+                                        sum = Float.MAX_VALUE;
+                                    } else if (sum < -Float.MAX_VALUE) {
+                                        sum = -Float.MAX_VALUE;
+                                    }
+
+                                    // The interpolated value is saved in the destination array
+                                    dstData[dstPixelOffset] = (float) sum;
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -3358,84 +3317,77 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     int x0 = src.getX() + posx / srcPixelStride;
                                     int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int pos = posx + posy;
 
-                                        int pos = posx + posy;
-
-                                        // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
-                                        // Otherwise it takes the related value.
-                                        int tempROI = 0;
-                                        // X offset initialization
-                                        int offsetX = 4 * xfrac[i];
-                                        // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                        // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                        // and by roiscanlinestride on the y axis.
-                                        for (int h = 0; h < 4; h++) {
-                                            for (int z = 0; z < 4; z++) {
-                                                // Selection of one pixel
-                                                pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                        * srcPixelStride + (h - 1)
-                                                        * srcScanlineStride];
-
-                                                tempROI += roiIter.getSample(x0 + h - 1,
-                                                        y0 + z - 1, 0);
-
-                                                if (!noData.contains((float) pixelKernel[h][z])) {
-                                                    weight |= (0x01 << (4 * h + z));
-                                                } else {
-                                                    weight &= (0xffff - (0x01 << 4 * h + z));
-                                                }
+                                    // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
+                                    // Otherwise it takes the related value.
+                                    int tempROI = 0;
+                                    // X offset initialization
+                                    int offsetX = 4 * xfrac[i];
+                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                    // and by roiscanlinestride on the y axis.
+                                    for (int h = 0; h < 4; h++) {
+                                        for (int z = 0; z < 4; z++) {
+                                            // Selection of one pixel
+                                            pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                    * srcPixelStride + (h - 1)
+                                                    * srcScanlineStride];
+                                            final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                    roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                            tempROI += increment;
+                                            if (!noData.contains((float) pixelKernel[h][z])) {
+                                                weight |= (0x01 << (4 * h + z));
+                                            } else {
+                                                weight &= (0xffff - (0x01 << 4 * h + z));
                                             }
                                         }
+                                    }
 
-                                        // Control if the 16 pixel are outside the ROI
-                                        if (weight == 0 || tempROI == 0) {
-                                            dstData[dstPixelOffset] = destinationNoDataFloat[k];
-                                        } else {
-
-                                            double sum = 0;
-
-                                            for (int h = 0; h < 4; h++) {
-                                                // Row temporary sum initialization
-                                                double tempSum = 0;
-                                                temp = (byte) ((weight >> 4 * h) & 0x0F);
-                                                double[] tempData = bicubicInpaintingDouble(
-                                                        pixelKernel[h], temp, emptyArray);
-                                                for (int z = 0; z < 4; z++) {
-                                                    // Update of the temporary sum
-                                                    tempSum += (tempData[z] * dataHf[offsetX + z]);
-                                                }
-                                                if (temp > 0) {
-                                                    weightVert |= (0x01 << h);
-                                                } else {
-                                                    weightVert &= (0x0F - (0x01 << h));
-                                                }
-                                                sumArray[h] = tempSum;
-                                            }
-
-                                            double[] tempData = bicubicInpaintingDouble(sumArray,
-                                                    weightVert, emptyArray);
-                                            weight = 0;
-                                            weightVert = 0;
-                                            // Vertical sum update
-                                            for (int h = 0; h < 4; h++) {
-                                                // Update of the temporary sum
-                                                sum += tempData[h] * dataVf[offsetY + h];
-                                            }
-
-                                            // Clamp
-                                            if (sum > Float.MAX_VALUE) {
-                                                sum = Float.MAX_VALUE;
-                                            } else if (sum < -Float.MAX_VALUE) {
-                                                sum = -Float.MAX_VALUE;
-                                            }
-
-                                            // The interpolated value is saved in the destination array
-                                            dstData[dstPixelOffset] = (float) sum;
-                                        }
-
-                                    } else {
+                                    // Control if the 16 pixel are outside the ROI
+                                    if (weight == 0 || tempROI == 0) {
                                         dstData[dstPixelOffset] = destinationNoDataFloat[k];
+                                    } else {
+
+                                        double sum = 0;
+
+                                        for (int h = 0; h < 4; h++) {
+                                            // Row temporary sum initialization
+                                            double tempSum = 0;
+                                            temp = (byte) ((weight >> 4 * h) & 0x0F);
+                                            double[] tempData = bicubicInpaintingDouble(
+                                                    pixelKernel[h], temp, emptyArray);
+                                            for (int z = 0; z < 4; z++) {
+                                                // Update of the temporary sum
+                                                tempSum += (tempData[z] * dataHf[offsetX + z]);
+                                            }
+                                            if (temp > 0) {
+                                                weightVert |= (0x01 << h);
+                                            } else {
+                                                weightVert &= (0x0F - (0x01 << h));
+                                            }
+                                            sumArray[h] = tempSum;
+                                        }
+
+                                        double[] tempData = bicubicInpaintingDouble(sumArray,
+                                                weightVert, emptyArray);
+                                        weight = 0;
+                                        weightVert = 0;
+                                        // Vertical sum update
+                                        for (int h = 0; h < 4; h++) {
+                                            // Update of the temporary sum
+                                            sum += tempData[h] * dataVf[offsetY + h];
+                                        }
+
+                                        // Clamp
+                                        if (sum > Float.MAX_VALUE) {
+                                            sum = Float.MAX_VALUE;
+                                        } else if (sum < -Float.MAX_VALUE) {
+                                            sum = -Float.MAX_VALUE;
+                                        }
+
+                                        // The interpolated value is saved in the destination array
+                                        dstData[dstPixelOffset] = (float) sum;
                                     }
 
                                     // destination pixel offset update
@@ -3648,45 +3600,41 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
 
                                 // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
                                 // Otherwise it takes the related value.
-                                if (roiBounds.contains(x0, y0)) {
-
-                                    int temp = 0;
-                                    // X offset initialization
-                                    int offsetX = 4 * xfrac[i];
-                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                    // and by roiscanlinestride on the y axis.
-                                    for (int h = 0; h < 4; h++) {
-                                        for (int z = 0; z < 4; z++) {
-                                            // Selection of one pixel
-                                            pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                    * srcPixelStride + (h - 1) * srcScanlineStride];
-                                            temp += roiIter.getSample(x0 + h - 1, y0 + z - 1, 0);
-                                        }
+                                int temp = 0;
+                                // X offset initialization
+                                int offsetX = 4 * xfrac[i];
+                                // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                // and by roiscanlinestride on the y axis.
+                                for (int h = 0; h < 4; h++) {
+                                    for (int z = 0; z < 4; z++) {
+                                        // Selection of one pixel
+                                        pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                * srcPixelStride + (h - 1) * srcScanlineStride];
+                                        final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                        temp += increment;
                                     }
-                                    // Control if the 16 pixel are outside the ROI
-                                    if (temp == 0) {
-                                        dstData[dstPixelOffset] = destinationNoDataDouble[k];
-                                    } else {
-                                        double sum = 0;
-
-                                        for (int h = 0; h < 4; h++) {
-                                            // Row temporary sum initialization
-                                            double tempSum = 0;
-                                            for (int z = 0; z < 4; z++) {
-                                                // Update of the temporary sum
-                                                tempSum += (pixelKernel[h][z] * dataHd[offsetX + z]);
-                                            }
-                                            // Vertical sum update
-                                            sum += tempSum * dataVd[offsetY + h];
-                                        }
-
-                                        // The interpolated value is saved in the destination array
-                                        dstData[dstPixelOffset] = sum;
-                                    }
-                                } else {
-                                    // The destination no data value is saved in the destination array
+                                }
+                                // Control if the 16 pixel are outside the ROI
+                                if (temp == 0) {
                                     dstData[dstPixelOffset] = destinationNoDataDouble[k];
+                                } else {
+                                    double sum = 0;
+
+                                    for (int h = 0; h < 4; h++) {
+                                        // Row temporary sum initialization
+                                        double tempSum = 0;
+                                        for (int z = 0; z < 4; z++) {
+                                            // Update of the temporary sum
+                                            tempSum += (pixelKernel[h][z] * dataHd[offsetX + z]);
+                                        }
+                                        // Vertical sum update
+                                        sum += tempSum * dataVd[offsetY + h];
+                                    }
+
+                                    // The interpolated value is saved in the destination array
+                                    dstData[dstPixelOffset] = sum;
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -3941,78 +3889,71 @@ public class ScaleBicubicOpImage extends ScaleOpImage {
                                     int x0 = src.getX() + posx / srcPixelStride;
                                     int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int pos = posx + posy;
 
-                                        int pos = posx + posy;
+                                    // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
+                                    // Otherwise it takes the related value.
 
-                                        // Check if the selected index belongs to the roi data array: if it is not present, the weight is 0,
-                                        // Otherwise it takes the related value.
-
-                                        int tempROI = 0;
-                                        // X offset initialization
-                                        int offsetX = 4 * xfrac[i];
-                                        // Cycle through all the 16 kernel pixel and calculation of the interpolated value
-                                        // and cycle for filling all the ROI index by shifting of 1 on the x axis
-                                        // and by roiscanlinestride on the y axis.
-                                        for (int h = 0; h < 4; h++) {
-                                            for (int z = 0; z < 4; z++) {
-                                                // Selection of one pixel
-                                                pixelKernel[h][z] = srcData[pos + (z - 1)
-                                                        * srcPixelStride + (h - 1)
-                                                        * srcScanlineStride];
-
-                                                tempROI += roiIter.getSample(x0 + h - 1,
-                                                        y0 + z - 1, 0);
-
-                                                if (!noData.contains(pixelKernel[h][z])) {
-                                                    weight |= (0x01 << (4 * h + z));
-                                                } else {
-                                                    weight &= (0xffff - (0x01 << 4 * h + z));
-                                                }
+                                    int tempROI = 0;
+                                    // X offset initialization
+                                    int offsetX = 4 * xfrac[i];
+                                    // Cycle through all the 16 kernel pixel and calculation of the interpolated value
+                                    // and cycle for filling all the ROI index by shifting of 1 on the x axis
+                                    // and by roiscanlinestride on the y axis.
+                                    for (int h = 0; h < 4; h++) {
+                                        for (int z = 0; z < 4; z++) {
+                                            // Selection of one pixel
+                                            pixelKernel[h][z] = srcData[pos + (z - 1)
+                                                    * srcPixelStride + (h - 1)
+                                                    * srcScanlineStride];
+                                            final int increment = roiBounds.contains(x0 + h - 1, y0 + z - 1) ?
+                                                    roiIter.getSample(x0 + h - 1, y0 + z - 1, 0) : 0;
+                                            tempROI += increment;
+                                            if (!noData.contains(pixelKernel[h][z])) {
+                                                weight |= (0x01 << (4 * h + z));
+                                            } else {
+                                                weight &= (0xffff - (0x01 << 4 * h + z));
                                             }
                                         }
+                                    }
 
-                                        // Control if the 16 pixel are outside the ROI
-                                        if (weight == 0 || tempROI == 0) {
-                                            dstData[dstPixelOffset] = destinationNoDataDouble[k];
-                                        } else {
-
-                                            double sum = 0;
-
-                                            for (int h = 0; h < 4; h++) {
-                                                // Row temporary sum initialization
-                                                double tempSum = 0;
-                                                temp = (byte) ((weight >> 4 * h) & 0x0F);
-                                                double[] tempData = bicubicInpaintingDouble(
-                                                        pixelKernel[h], temp, emptyArray);
-                                                for (int z = 0; z < 4; z++) {
-                                                    // Update of the temporary sum
-                                                    tempSum += (tempData[z] * dataHd[offsetX + z]);
-                                                }
-                                                if (temp > 0) {
-                                                    weightVert |= (0x01 << h);
-                                                } else {
-                                                    weightVert &= (0x0F - (0x01 << h));
-                                                }
-                                                sumArray[h] = tempSum;
-                                            }
-
-                                            double[] tempData = bicubicInpaintingDouble(sumArray,
-                                                    weightVert, emptyArray);
-                                            weight = 0;
-                                            weightVert = 0;
-                                            // Vertical sum update
-                                            for (int h = 0; h < 4; h++) {
-                                                // Update of the temporary sum
-                                                sum += tempData[h] * dataVd[offsetY + h];
-                                            }
-
-                                            // The interpolated value is saved in the destination array
-                                            dstData[dstPixelOffset] = sum;
-                                        }
-
-                                    } else {
+                                    // Control if the 16 pixel are outside the ROI
+                                    if (weight == 0 || tempROI == 0) {
                                         dstData[dstPixelOffset] = destinationNoDataDouble[k];
+                                    } else {
+
+                                        double sum = 0;
+
+                                        for (int h = 0; h < 4; h++) {
+                                            // Row temporary sum initialization
+                                            double tempSum = 0;
+                                            temp = (byte) ((weight >> 4 * h) & 0x0F);
+                                            double[] tempData = bicubicInpaintingDouble(
+                                                    pixelKernel[h], temp, emptyArray);
+                                            for (int z = 0; z < 4; z++) {
+                                                // Update of the temporary sum
+                                                tempSum += (tempData[z] * dataHd[offsetX + z]);
+                                            }
+                                            if (temp > 0) {
+                                                weightVert |= (0x01 << h);
+                                            } else {
+                                                weightVert &= (0x0F - (0x01 << h));
+                                            }
+                                            sumArray[h] = tempSum;
+                                        }
+
+                                        double[] tempData = bicubicInpaintingDouble(sumArray,
+                                                weightVert, emptyArray);
+                                        weight = 0;
+                                        weightVert = 0;
+                                        // Vertical sum update
+                                        for (int h = 0; h < 4; h++) {
+                                            // Update of the temporary sum
+                                            sum += tempData[h] * dataVd[offsetY + h];
+                                        }
+
+                                        // The interpolated value is saved in the destination array
+                                        dstData[dstPixelOffset] = sum;
                                     }
 
                                     // destination pixel offset update

--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleBilinearOpImage.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleBilinearOpImage.java
@@ -55,6 +55,7 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
     // Use weighted contribute only if the fraction is greater than the threshold.
     private final static int FRACTION_THRESHOLD_I = 128;
     private final static int FULL_WEIGHT_SHIFT = 8; // a*256 = a<<8
+    private InterpolationBilinear bilinearInterpolator;
 
     public ScaleBilinearOpImage(RenderedImage source, ImageLayout layout, Map configuration,
             BorderExtender extender, Interpolation interp, float scaleX, float scaleY,
@@ -149,7 +150,7 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
         shift = 29 - subsampleBits;
         shift2 = 2 * subsampleBits;
         round2 = 1 << (shift2 - 1);
-
+        
         // Number of subsample positions
         one = 1 << subsampleBits;
 
@@ -201,6 +202,14 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
         caseB = hasROI && !hasNoData;
         caseC = !hasROI && hasNoData;
 
+        // object to delegate to directly to avoid code duplication
+        int denstinationDataType = getSampleModel().getDataType();
+        if (!caseA && (denstinationDataType == DataBuffer.TYPE_BYTE ||
+                denstinationDataType == DataBuffer.TYPE_SHORT ||
+                denstinationDataType == DataBuffer.TYPE_USHORT ||
+                denstinationDataType == DataBuffer.TYPE_INT)) {
+            bilinearInterpolator = new InterpolationBilinear(subsampleBits, nodata, false, destinationNoData, denstinationDataType);
+        }
     }
 
     @Override
@@ -430,16 +439,14 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int w11 = w11index < roiDataLength ? roiDataArray[w11index] & 0xff
                                         : 0;
 
-                                if (baseIndex > roiDataLength || w00 == 0) {
+                                if (baseIndex > roiDataLength) {
                                     dstData[dstPixelOffset] = destinationNoDataByte[k];
                                 } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataByte[k];
                                 } else {
                                     // Perform the bilinear interpolation
-                                    final int s0 = (s01 - s00) * xfrac[i] + (s00 << subsampleBits);
-                                    final int s1 = (s11 - s10) * xfrac[i] + (s10 << subsampleBits);
-                                    final int s = ((s1 - s0) * yfrac[j] + (s0 << subsampleBits) + round2) >> shift2;
+                                    final int s = computeValue(s00, s01, s10, s11, w00, w01, w10, w11, xfrac[i], yfrac[j], k);
 
                                     // The interpolated value is saved in the destination array
                                     dstData[dstPixelOffset] = (byte) (s & 0xff);
@@ -474,37 +481,28 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int x0 = src.getX() + posx / srcPixelStride;
                                 final int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                if (roiBounds.contains(x0, y0)) {
+                                final int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                final int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                final int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                final int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                    final int w00 = roiIter.getSample(x0, y0, 0);
-                                    final int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                    final int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                    final int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                        // The destination no data value is saved in the destination array
-                                        dstData[dstPixelOffset] = destinationNoDataByte[k];
-                                    } else {
-                                        // Get the four surrounding pixel values
-                                        final int s00 = srcData[posx + posy] & 0xff;
-                                        final int s01 = srcData[posx + srcPixelStride + posy] & 0xff;
-                                        final int s10 = srcData[posx + posy + srcScanlineStride] & 0xff;
-                                        final int s11 = srcData[posx + srcPixelStride + posy
-                                                + srcScanlineStride] & 0xff;
-                                        // Perform the bilinear interpolation
-                                        final int s0 = (s01 - s00) * xfrac[i]
-                                                + (s00 << subsampleBits);
-                                        final int s1 = (s11 - s10) * xfrac[i]
-                                                + (s10 << subsampleBits);
-                                        final int s = ((s1 - s0) * yfrac[j] + (s0 << subsampleBits) + round2) >> shift2;
-
-                                        // The interpolated value is saved in the destination array
-                                        dstData[dstPixelOffset] = (byte) (s & 0xff);
-                                    }
-                                } else {
+                                if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataByte[k];
+                                } else {
+                                    // Get the four surrounding pixel values
+                                    final int s00 = srcData[posx + posy] & 0xff;
+                                    final int s01 = srcData[posx + srcPixelStride + posy] & 0xff;
+                                    final int s10 = srcData[posx + posy + srcScanlineStride] & 0xff;
+                                    final int s11 = srcData[posx + srcPixelStride + posy
+                                            + srcScanlineStride] & 0xff;
+                                    // Perform the bilinear interpolation
+                                    final int s = computeValue(s00, s01, s10, s11, w00, w01, w10, w11, xfrac[i], yfrac[j], k);
+
+                                    // The interpolated value is saved in the destination array
+                                    dstData[dstPixelOffset] = (byte) (s & 0xff);
                                 }
+                                
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
                             }
@@ -618,17 +616,17 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     int w11 = w11index < roiDataLength ? roiDataArray[w11index] & 0xff
                                             : 0;
 
-                                    if (baseIndex > roiDataLength || w00 == 0) {
+                                    if (baseIndex > roiDataLength) {
                                         dstData[dstPixelOffset] = destinationNoDataByte[k];
                                     } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataByte[k];
                                     } else {
 
-                                        w00 = byteLookupTable[k][s00] == destinationNoDataByte[k] ? 0 : 1;
-                                        w01 = byteLookupTable[k][s01] == destinationNoDataByte[k] ? 0 : 1;
-                                        w10 = byteLookupTable[k][s10] == destinationNoDataByte[k] ? 0 : 1;
-                                        w11 = byteLookupTable[k][s11] == destinationNoDataByte[k] ? 0 : 1;
+                                        w00 = byteLookupTable[k][s00] == destinationNoDataByte[k] ? 0 : w00;
+                                        w01 = byteLookupTable[k][s01] == destinationNoDataByte[k] ? 0 : w01;
+                                        w10 = byteLookupTable[k][s10] == destinationNoDataByte[k] ? 0 : w10;
+                                        w11 = byteLookupTable[k][s11] == destinationNoDataByte[k] ? 0 : w11;
 
                                         // The interpolated value is saved in the destination array
                                         dstData[dstPixelOffset] = (byte) (computeValue(s00, s01,
@@ -666,38 +664,32 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     final int y0 = src.getY() + (posy - bandOffset)
                                             / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                    int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                    int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                    int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                        int w00 = roiIter.getSample(x0, y0, 0);
-                                        int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                        int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                        int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                        if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                            // The destination no data value is saved in the destination array
-                                            dstData[dstPixelOffset] = destinationNoDataByte[k];
-                                        } else {
-
-                                            // Get the four surrounding pixel values
-                                            final int s00 = srcData[posx + posy] & 0xff;
-                                            final int s01 = srcData[posx + srcPixelStride + posy] & 0xff;
-                                            final int s10 = srcData[posx + posy + srcScanlineStride] & 0xff;
-                                            final int s11 = srcData[posx + srcPixelStride + posy
-                                                    + srcScanlineStride] & 0xff;
-
-                                            w00 = byteLookupTable[k][s00] == destinationNoDataByte[k] ? 0 : 1;
-                                            w01 = byteLookupTable[k][s01] == destinationNoDataByte[k] ? 0 : 1;
-                                            w10 = byteLookupTable[k][s10] == destinationNoDataByte[k] ? 0 : 1;
-                                            w11 = byteLookupTable[k][s11] == destinationNoDataByte[k] ? 0 : 1;
-
-                                            // compute value
-                                            dstData[dstPixelOffset] = (byte) (computeValue(s00,
-                                                    s01, s10, s11, w00, w01, w10, w11, xfrac[i],
-                                                    yfrac[j], k) & 0xff);
-                                        }
-                                    } else {
+                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataByte[k];
+                                    } else {
+
+                                        // Get the four surrounding pixel values
+                                        final int s00 = srcData[posx + posy] & 0xff;
+                                        final int s01 = srcData[posx + srcPixelStride + posy] & 0xff;
+                                        final int s10 = srcData[posx + posy + srcScanlineStride] & 0xff;
+                                        final int s11 = srcData[posx + srcPixelStride + posy
+                                                + srcScanlineStride] & 0xff;
+
+                                        w00 = byteLookupTable[k][s00] == destinationNoDataByte[k] ? 0 : w00;
+                                        w01 = byteLookupTable[k][s01] == destinationNoDataByte[k] ? 0 : w01;
+                                        w10 = byteLookupTable[k][s10] == destinationNoDataByte[k] ? 0 : w10;
+                                        w11 = byteLookupTable[k][s11] == destinationNoDataByte[k] ? 0 : w11;
+
+                                        // compute value
+                                        dstData[dstPixelOffset] = (byte) (computeValue(s00,
+                                                s01, s10, s11, w00, w01, w10, w11, xfrac[i],
+                                                yfrac[j], k) & 0xff);
                                     }
 
                                     // destination pixel offset update
@@ -830,16 +822,14 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int w11 = w11index < roiDataLength ? roiDataArray[w11index] & 0xffff
                                         : 0;
 
-                                if (baseIndex > roiDataLength || w00 == 0) {
+                                if (baseIndex > roiDataLength) {
                                     dstData[dstPixelOffset] = destinationNoDataUShort[k];
                                 } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataUShort[k];
                                 } else {
                                     // Perform the bilinear interpolation
-                                    final int s0 = (s01 - s00) * xfrac[i] + (s00 << subsampleBits);
-                                    final int s1 = (s11 - s10) * xfrac[i] + (s10 << subsampleBits);
-                                    final int s = ((s1 - s0) * yfrac[j] + (s0 << subsampleBits) + round2) >> shift2;
+                                    final int s = computeValue(s00, s01, s10, s11, w00, w01, w10, w11, xfrac[i], yfrac[j], k);
 
                                     // The interpolated value is saved in the destination array
                                     dstData[dstPixelOffset] = (short) (s & 0xffff);
@@ -874,37 +864,26 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int x0 = src.getX() + posx / srcPixelStride;
                                 final int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                if (roiBounds.contains(x0, y0)) {
+                                final int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                final int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                final int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                final int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                    final int w00 = roiIter.getSample(x0, y0, 0);
-                                    final int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                    final int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                    final int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                        // The destination no data value is saved in the destination array
-                                        dstData[dstPixelOffset] = destinationNoDataUShort[k];
-
-                                    } else {
-                                        // Get the four surrounding pixel values
-                                        final int s00 = srcData[posx + posy] & 0xffff;
-                                        final int s01 = srcData[posx + srcPixelStride + posy] & 0xffff;
-                                        final int s10 = srcData[posx + posy + srcScanlineStride] & 0xffff;
-                                        final int s11 = srcData[posx + srcPixelStride + posy
-                                                + srcScanlineStride] & 0xffff;
-                                        // Perform the bilinear interpolation
-                                        final int s0 = (s01 - s00) * xfrac[i]
-                                                + (s00 << subsampleBits);
-                                        final int s1 = (s11 - s10) * xfrac[i]
-                                                + (s10 << subsampleBits);
-                                        final int s = ((s1 - s0) * yfrac[j] + (s0 << subsampleBits) + round2) >> shift2;
-
-                                        // The interpolated value is saved in the destination array
-                                        dstData[dstPixelOffset] = (short) (s & 0xffff);
-                                    }
-                                } else {
+                                if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataUShort[k];
+                                } else {
+                                    // Get the four surrounding pixel values
+                                    final int s00 = srcData[posx + posy] & 0xffff;
+                                    final int s01 = srcData[posx + srcPixelStride + posy] & 0xffff;
+                                    final int s10 = srcData[posx + posy + srcScanlineStride] & 0xffff;
+                                    final int s11 = srcData[posx + srcPixelStride + posy
+                                            + srcScanlineStride] & 0xffff;
+                                    // Perform the bilinear interpolation
+                                    final int s = computeValue(s00, s01, s10, s11, w00, w01, w10, w11, xfrac[i], yfrac[j], k);
+
+                                    // The interpolated value is saved in the destination array
+                                    dstData[dstPixelOffset] = (short) (s & 0xffff);
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -1009,16 +988,16 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     int w11 = w11index < roiDataLength ? roiDataArray[w11index] & 0xffff
                                             : 0;
 
-                                    if (baseIndex > roiDataLength || w00 == 0) {
+                                    if (baseIndex > roiDataLength) {
                                         dstData[dstPixelOffset] = destinationNoDataUShort[k];
                                     } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataUShort[k];
                                     } else {
-                                        w00 = noData.contains(s00) ? 0 : 1;
-                                        w01 = noData.contains(s01) ? 0 : 1;
-                                        w10 = noData.contains(s10) ? 0 : 1;
-                                        w11 = noData.contains(s11) ? 0 : 1;
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
 
                                         // The interpolated value is saved in the destination array
                                         dstData[dstPixelOffset] = (short) (computeValue(s00, s01,
@@ -1056,39 +1035,33 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     final int y0 = src.getY() + (posy - bandOffset)
                                             / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                    int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                    int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                    int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                        int w00 = roiIter.getSample(x0, y0, 0);
-                                        int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                        int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                        int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                        if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                            // The destination no data value is saved in the destination array
-                                            dstData[dstPixelOffset] = destinationNoDataUShort[k];
-                                        } else {
-                                            // Get the four surrounding pixel values
-                                            final short s00 = (short) (srcData[posx + posy] & 0xffff);
-                                            final short s01 = (short) (srcData[posx
-                                                    + srcPixelStride + posy] & 0xffff);
-                                            final short s10 = (short) (srcData[posx + posy
-                                                    + srcScanlineStride] & 0xffff);
-                                            final short s11 = (short) (srcData[posx
-                                                    + srcPixelStride + posy + srcScanlineStride] & 0xffff);
-
-                                            w00 = noData.contains(s00) ? 0 : 1;
-                                            w01 = noData.contains(s01) ? 0 : 1;
-                                            w10 = noData.contains(s10) ? 0 : 1;
-                                            w11 = noData.contains(s11) ? 0 : 1;
-
-                                            // compute value
-                                            dstData[dstPixelOffset] = (short) (computeValue(s00,
-                                                    s01, s10, s11, w00, w01, w10, w11, xfrac[i],
-                                                    yfrac[j], k) & 0xffff);
-                                        }
-                                    } else {
+                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataUShort[k];
+                                    } else {
+                                        // Get the four surrounding pixel values
+                                        final short s00 = (short) (srcData[posx + posy] & 0xffff);
+                                        final short s01 = (short) (srcData[posx
+                                                + srcPixelStride + posy] & 0xffff);
+                                        final short s10 = (short) (srcData[posx + posy
+                                                + srcScanlineStride] & 0xffff);
+                                        final short s11 = (short) (srcData[posx
+                                                + srcPixelStride + posy + srcScanlineStride] & 0xffff);
+
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
+
+                                        // compute value
+                                        dstData[dstPixelOffset] = (short) (computeValue(s00,
+                                                s01, s10, s11, w00, w01, w10, w11, xfrac[i],
+                                                yfrac[j], k) & 0xffff);
                                     }
 
                                     // destination pixel offset update
@@ -1222,16 +1195,14 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int w11 = w11index < roiDataLength ? roiDataArray[w11index]
                                         : 0;
 
-                                if (baseIndex > roiDataLength || w00 == 0) {
+                                if (baseIndex > roiDataLength) {
                                     dstData[dstPixelOffset] = destinationNoDataShort[k];
                                 } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataShort[k];
                                 } else {
                                     // Perform the bilinear interpolation
-                                    final int s0 = (s01 - s00) * xfrac[i] + (s00 << subsampleBits);
-                                    final int s1 = (s11 - s10) * xfrac[i] + (s10 << subsampleBits);
-                                    final int s = ((s1 - s0) * yfrac[j] + (s0 << subsampleBits) + round2) >> shift2;
+                                    final int s = computeValue(s00, s01, s10, s11, w00, w01, w10, w11, xfrac[i], yfrac[j], k);
 
                                     // The interpolated value is saved in the destination array
                                     dstData[dstPixelOffset] = (short) s;
@@ -1266,37 +1237,27 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int x0 = src.getX() + posx / srcPixelStride;
                                 final int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                if (roiBounds.contains(x0, y0)) {
+                                final int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                final int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                final int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                final int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                    final int w00 = roiIter.getSample(x0, y0, 0);
-                                    final int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                    final int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                    final int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                        // The destination no data value is saved in the destination array
-                                        dstData[dstPixelOffset] = destinationNoDataShort[k];
-                                    } else {
-                                        // Get the four surrounding pixel values
-                                        final int s00 = srcData[posx + posy];
-                                        final int s01 = srcData[posx + srcPixelStride + posy];
-                                        final int s10 = srcData[posx + posy + srcScanlineStride];
-                                        final int s11 = srcData[posx + srcPixelStride + posy
-                                                + srcScanlineStride];
-                                        // Perform the bilinear interpolation
-                                        final int s0 = (s01 - s00) * xfrac[i]
-                                                + (s00 << subsampleBits);
-                                        final int s1 = (s11 - s10) * xfrac[i]
-                                                + (s10 << subsampleBits);
-                                        final int s = ((s1 - s0) * yfrac[j] + (s0 << subsampleBits) + round2) >> shift2;
-
-                                        // The interpolated value is saved in the destination array
-                                        dstData[dstPixelOffset] = (short) s;
-                                    }
-                                } else {
+                                if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataShort[k];
-                                }
+                                } else {
+                                    // Get the four surrounding pixel values
+                                    final int s00 = srcData[posx + posy];
+                                    final int s01 = srcData[posx + srcPixelStride + posy];
+                                    final int s10 = srcData[posx + posy + srcScanlineStride];
+                                    final int s11 = srcData[posx + srcPixelStride + posy
+                                            + srcScanlineStride];
+                                    // Perform the bilinear interpolation
+                                    final int s = computeValue(s00, s01, s10, s11, w00, w01, w10, w11, xfrac[i], yfrac[j], k);
+
+                                    // The interpolated value is saved in the destination array
+                                    dstData[dstPixelOffset] = (short) s;
+                                    }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
                             }
@@ -1395,17 +1356,16 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     int w10 = w10index < roiDataLength ? roiDataArray[w10index] : 0;
                                     int w11 = w11index < roiDataLength ? roiDataArray[w11index] : 0;
 
-                                    if (baseIndex > roiDataLength || w00 == 0) {
+                                    if (baseIndex > roiDataLength) {
                                         dstData[dstPixelOffset] = destinationNoDataShort[k];
                                     } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataShort[k];
                                     } else {
-
-                                        w00 = noData.contains(s00) ? 0 : 1;
-                                        w01 = noData.contains(s01) ? 0 : 1;
-                                        w10 = noData.contains(s10) ? 0 : 1;
-                                        w11 = noData.contains(s11) ? 0 : 1;
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
 
                                         // The interpolated value is saved in the destination array
                                         dstData[dstPixelOffset] = (short) (computeValue(s00, s01,
@@ -1443,38 +1403,32 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     final int y0 = src.getY() + (posy - bandOffset)
                                             / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                    int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                    int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                    int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                        int w00 = roiIter.getSample(x0, y0, 0);
-                                        int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                        int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                        int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                        if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                            // The destination no data value is saved in the destination array
-                                            dstData[dstPixelOffset] = destinationNoDataShort[k];
-                                        } else {
-                                            // Get the four surrounding pixel values
-                                            final short s00 = srcData[posx + posy];
-                                            final short s01 = srcData[posx + srcPixelStride + posy];
-                                            final short s10 = srcData[posx + posy
-                                                    + srcScanlineStride];
-                                            final short s11 = srcData[posx + srcPixelStride + posy
-                                                    + srcScanlineStride];
-
-                                            w00 = noData.contains(s00) ? 0 : 1;
-                                            w01 = noData.contains(s01) ? 0 : 1;
-                                            w10 = noData.contains(s10) ? 0 : 1;
-                                            w11 = noData.contains(s11) ? 0 : 1;
-
-                                            // compute value
-                                            dstData[dstPixelOffset] = (short) (computeValue(s00,
-                                                    s01, s10, s11, w00, w01, w10, w11, xfrac[i],
-                                                    yfrac[j], k));
-                                        }
-                                    } else {
+                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataShort[k];
+                                    } else {
+                                        // Get the four surrounding pixel values
+                                        final short s00 = srcData[posx + posy];
+                                        final short s01 = srcData[posx + srcPixelStride + posy];
+                                        final short s10 = srcData[posx + posy
+                                                + srcScanlineStride];
+                                        final short s11 = srcData[posx + srcPixelStride + posy
+                                                + srcScanlineStride];
+
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
+
+                                        // compute value
+                                        dstData[dstPixelOffset] = (short) (computeValue(s00,
+                                                s01, s10, s11, w00, w01, w10, w11, xfrac[i],
+                                                yfrac[j], k));
                                     }
 
                                     // destination pixel offset update
@@ -1608,15 +1562,15 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int w11 = w11index < roiDataLength ? roiDataArray[w11index]
                                         : 0;
 
-                                if (baseIndex > roiDataLength || w00 == 0) {
+                                if (baseIndex > roiDataLength) {
                                     dstData[dstPixelOffset] = destinationNoDataInt[k];
                                 } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataInt[k];
                                 } else {
                                     // The interpolated value is saved in the destination array
-                                    dstData[dstPixelOffset] = (computeValue(s00, s01, s10, s11, 1,
-                                            1, 1, 1, xfrac[i], yfrac[j], k));
+                                    dstData[dstPixelOffset] = computeValue(s00, s01, s10, s11, w00,
+                                            w01, w10, w11, xfrac[i], yfrac[j], k);
                                 }
 
                                 // destination pixel offset update
@@ -1648,30 +1602,24 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int x0 = src.getX() + posx / srcPixelStride;
                                 final int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                if (roiBounds.contains(x0, y0)) {
+                                final int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                final int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                final int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                final int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                    final int w00 = roiIter.getSample(x0, y0, 0);
-                                    final int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                    final int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                    final int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                        // The destination no data value is saved in the destination array
-                                        dstData[dstPixelOffset] = destinationNoDataInt[k];
-                                    } else {
-                                        // Get the four surrounding pixel values
-                                        final int s00 = srcData[posx + posy];
-                                        final int s01 = srcData[posx + srcPixelStride + posy];
-                                        final int s10 = srcData[posx + posy + srcScanlineStride];
-                                        final int s11 = srcData[posx + srcPixelStride + posy
-                                                + srcScanlineStride];
-                                        // compute value
-                                        dstData[dstPixelOffset] = (computeValue(s00, s01, s10, s11,
-                                                1, 1, 1, 1, xfrac[i], yfrac[j], k));
-                                    }
-                                } else {
+                                if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataInt[k];
+                                } else {
+                                    // Get the four surrounding pixel values
+                                    final int s00 = srcData[posx + posy];
+                                    final int s01 = srcData[posx + srcPixelStride + posy];
+                                    final int s10 = srcData[posx + posy + srcScanlineStride];
+                                    final int s11 = srcData[posx + srcPixelStride + posy
+                                            + srcScanlineStride];
+                                    // compute value
+                                    dstData[dstPixelOffset] = (computeValue(s00, s01, s10, s11,
+                                            w00, w01, w10, w11, xfrac[i], yfrac[j], k));
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -1771,16 +1719,16 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     int w10 = w10index < roiDataLength ? roiDataArray[w10index] : 0;
                                     int w11 = w11index < roiDataLength ? roiDataArray[w11index] : 0;
 
-                                    if (baseIndex > roiDataLength || w00 == 0) {
+                                    if (baseIndex > roiDataLength) {
                                         dstData[dstPixelOffset] = destinationNoDataInt[k];
                                     } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataInt[k];
                                     } else {
-                                        w00 = noData.contains(s00) ? 0 : 1;
-                                        w01 = noData.contains(s01) ? 0 : 1;
-                                        w10 = noData.contains(s10) ? 0 : 1;
-                                        w11 = noData.contains(s11) ? 0 : 1;
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
 
                                         // The interpolated value is saved in the destination array
                                         dstData[dstPixelOffset] = (computeValue(s00, s01, s10, s11,
@@ -1818,36 +1766,30 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     final int y0 = src.getY() + (posy - bandOffset)
                                             / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                    int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                    int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                    int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                        int w00 = roiIter.getSample(x0, y0, 0);
-                                        int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                        int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                        int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                        if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                            // The destination no data value is saved in the destination array
-                                            dstData[dstPixelOffset] = destinationNoDataInt[k];
-                                        } else {
-                                            // Get the four surrounding pixel values
-                                            final int s00 = srcData[posx + posy];
-                                            final int s01 = srcData[posx + srcPixelStride + posy];
-                                            final int s10 = srcData[posx + posy + srcScanlineStride];
-                                            final int s11 = srcData[posx + srcPixelStride + posy
-                                                    + srcScanlineStride];
-
-                                            w00 = noData.contains(s00) ? 0 : 1;
-                                            w01 = noData.contains(s01) ? 0 : 1;
-                                            w10 = noData.contains(s10) ? 0 : 1;
-                                            w11 = noData.contains(s11) ? 0 : 1;
-
-                                            // compute value
-                                            dstData[dstPixelOffset] = (computeValue(s00, s01, s10,
-                                                    s11, w00, w01, w10, w11, xfrac[i], yfrac[j], k));
-                                        }
-                                    } else {
+                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataInt[k];
+                                    } else {
+                                        // Get the four surrounding pixel values
+                                        final int s00 = srcData[posx + posy];
+                                        final int s01 = srcData[posx + srcPixelStride + posy];
+                                        final int s10 = srcData[posx + posy + srcScanlineStride];
+                                        final int s11 = srcData[posx + srcPixelStride + posy
+                                                + srcScanlineStride];
+
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
+
+                                        // compute value
+                                        dstData[dstPixelOffset] = (computeValue(s00, s01, s10,
+                                                s11, w00, w01, w10, w11, xfrac[i], yfrac[j], k));
                                     }
 
                                     // destination pixel offset update
@@ -1982,16 +1924,16 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int w11 = w11index < roiDataLength ? roiDataArray[w11index]
                                         : 0;
 
-                                if (baseIndex > roiDataLength || w00 == 0) {
+                                if (baseIndex > roiDataLength) {
                                     dstData[dstPixelOffset] = destinationNoDataFloat[k];
                                 } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataFloat[k];
                                 } else {
                                     // Perform the bilinear interpolation
-                                    final float s0 = (s01 - s00) * xfrac[i] + s00;
-                                    final float s1 = (s11 - s10) * xfrac[i] + s10;
-                                    final float s = (s1 - s0) * yfrac[j] + s0;
+                                    final float s = InterpolationBilinear.computeValueDouble(s00, s01,
+                                            s10, s11, w00 == 0, w01 == 0, w10 == 0, w11 == 0, xfrac[i], yfrac[j],
+                                            dataType, destinationNoDataFloat[k]).floatValue();
 
                                     // The interpolated value is saved in the destination array
                                     dstData[dstPixelOffset] = s;
@@ -2026,35 +1968,30 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int x0 = src.getX() + posx / srcPixelStride;
                                 final int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                if (roiBounds.contains(x0, y0)) {
+                                final int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                final int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                final int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                final int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                    final int w00 = roiIter.getSample(x0, y0, 0);
-                                    final int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                    final int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                    final int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
 
-                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                        // The destination no data value is saved in the destination array
-                                        dstData[dstPixelOffset] = destinationNoDataFloat[k];
-                                    } else {
-
-                                        // Get the four surrounding pixel values
-                                        final float s00 = srcData[posx + posy];
-                                        final float s01 = srcData[posx + srcPixelStride + posy];
-                                        final float s10 = srcData[posx + posy + srcScanlineStride];
-                                        final float s11 = srcData[posx + srcPixelStride + posy
-                                                + srcScanlineStride];
-                                        // Perform the bilinear interpolation
-                                        final float s0 = (s01 - s00) * xfrac[i] + s00;
-                                        final float s1 = (s11 - s10) * xfrac[i] + s10;
-                                        final float s = (s1 - s0) * yfrac[j] + s0;
-
-                                        // The interpolated value is saved in the destination array
-                                        dstData[dstPixelOffset] = s;
-                                    }
-                                } else {
+                                if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataFloat[k];
+                                } else {
+
+                                    // Get the four surrounding pixel values
+                                    final float s00 = srcData[posx + posy];
+                                    final float s01 = srcData[posx + srcPixelStride + posy];
+                                    final float s10 = srcData[posx + posy + srcScanlineStride];
+                                    final float s11 = srcData[posx + srcPixelStride + posy
+                                            + srcScanlineStride];
+                                    // Perform the bilinear interpolation
+                                    final float s = InterpolationBilinear.computeValueDouble(s00, s01,
+                                            s10, s11, w00 == 0, w01 == 0, w10 == 0, w11 == 0, xfrac[i], yfrac[j],
+                                            dataType, destinationNoDataFloat[k]).floatValue();
+
+                                    // The interpolated value is saved in the destination array
+                                    dstData[dstPixelOffset] = s;
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -2155,21 +2092,20 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     int w10 = w10index < roiDataLength ? roiDataArray[w10index] : 0;
                                     int w11 = w11index < roiDataLength ? roiDataArray[w11index] : 0;
 
-                                    if (baseIndex > roiDataLength || w00 == 0) {
+                                    if (baseIndex > roiDataLength) {
                                         dstData[dstPixelOffset] = destinationNoDataFloat[k];
                                     } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataFloat[k];
                                     } else {
-
-                                        boolean w00z = noData.contains(s00);
-                                        boolean w01z = noData.contains(s01);
-                                        boolean w10z = noData.contains(s10);
-                                        boolean w11z = noData.contains(s11);
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
 
                                         // The interpolated value is saved in the destination array
                                         dstData[dstPixelOffset] = InterpolationBilinear.computeValueDouble(s00,
-                                                s01, s10, s11, w00z, w01z, w10z, w11z, xfrac[i],
+                                                s01, s10, s11, w00 == 0, w01 == 0, w10 == 0, w11 == 0, xfrac[i],
                                                 yfrac[j], dataType, destinationNoDataFloat[k]).floatValue();
                                     }
                                     // destination pixel offset update
@@ -2204,38 +2140,32 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     final int y0 = src.getY() + (posy - bandOffset)
                                             / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                    int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                    int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                    int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                        int w00 = roiIter.getSample(x0, y0, 0);
-                                        int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                        int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                        int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                        if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                            // The destination no data value is saved in the destination array
-                                            dstData[dstPixelOffset] = destinationNoDataFloat[k];
-                                        } else {
-                                            // Get the four surrounding pixel values
-                                            final float s00 = srcData[posx + posy];
-                                            final float s01 = srcData[posx + srcPixelStride + posy];
-                                            final float s10 = srcData[posx + posy
-                                                    + srcScanlineStride];
-                                            final float s11 = srcData[posx + srcPixelStride + posy
-                                                    + srcScanlineStride];
-
-                                            boolean w00z = noData.contains(s00);
-                                            boolean w01z = noData.contains(s01);
-                                            boolean w10z = noData.contains(s10);
-                                            boolean w11z = noData.contains(s11);
-
-                                            // compute value
-                                            dstData[dstPixelOffset] = InterpolationBilinear.computeValueDouble(
-                                                    s00, s01, s10, s11, w00z, w01z, w10z, w11z,
-                                                    xfrac[i], yfrac[j], dataType, destinationNoDataFloat[k]).floatValue();
-                                        }
-                                    } else {
+                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataFloat[k];
+                                    } else {
+                                        // Get the four surrounding pixel values
+                                        final float s00 = srcData[posx + posy];
+                                        final float s01 = srcData[posx + srcPixelStride + posy];
+                                        final float s10 = srcData[posx + posy
+                                                + srcScanlineStride];
+                                        final float s11 = srcData[posx + srcPixelStride + posy
+                                                + srcScanlineStride];
+
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
+
+                                        // compute value
+                                        dstData[dstPixelOffset] = InterpolationBilinear.computeValueDouble(
+                                                s00, s01, s10, s11, w00 == 0, w01 == 0, w10 == 0, w11 == 0,
+                                                xfrac[i], yfrac[j], dataType, destinationNoDataFloat[k]).floatValue();
                                     }
 
                                     // destination pixel offset update
@@ -2369,16 +2299,15 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int w11 = w11index < roiDataLength ? roiDataArray[w11index]
                                         : 0;
 
-                                if (baseIndex > roiDataLength || w00 == 0) {
+                                if (baseIndex > roiDataLength) {
                                     dstData[dstPixelOffset] = destinationNoDataDouble[k];
                                 } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataDouble[k];
                                 } else {
                                     // Perform the bilinear interpolation
-                                    final double s0 = (s01 - s00) * xfrac[i] + s00;
-                                    final double s1 = (s11 - s10) * xfrac[i] + s10;
-                                    final double s = (s1 - s0) * yfrac[j] + s0;
+                                    final double s = InterpolationBilinear.computeValueDouble(s00, s01, s10,
+                                            s11, w00 == 0, w01 == 0, w10 == 0, w11 == 0, xfrac[i], yfrac[j], dataType, destinationNoDataDouble[k]).doubleValue();
 
                                     // The interpolated value is saved in the destination array
                                     dstData[dstPixelOffset] = s;
@@ -2413,34 +2342,27 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                 final int x0 = src.getX() + posx / srcPixelStride;
                                 final int y0 = src.getY() + (posy - bandOffset) / srcScanlineStride;
 
-                                if (roiBounds.contains(x0, y0)) {
-
-                                    final int w00 = roiIter.getSample(x0, y0, 0);
-                                    final int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                    final int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                    final int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
-
-                                    if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-                                        // The destination no data value is saved in the destination array
-                                        dstData[dstPixelOffset] = destinationNoDataDouble[k];
-                                    } else {
-                                        // Get the four surrounding pixel values
-                                        final double s00 = srcData[posx + posy];
-                                        final double s01 = srcData[posx + srcPixelStride + posy];
-                                        final double s10 = srcData[posx + posy + srcScanlineStride];
-                                        final double s11 = srcData[posx + srcPixelStride + posy
-                                                + srcScanlineStride];
-                                        // Perform the bilinear interpolation
-                                        final double s0 = (s01 - s00) * xfrac[i];
-                                        final double s1 = (s11 - s10) * xfrac[i];
-                                        final double s = (s1 - s0) * yfrac[j] + s0;
-
-                                        // The interpolated value is saved in the destination array
-                                        dstData[dstPixelOffset] = s;
-                                    }
-                                } else {
+                                final int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                final int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                final int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                final int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
+                                
+                                if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                     // The destination no data value is saved in the destination array
                                     dstData[dstPixelOffset] = destinationNoDataDouble[k];
+                                } else {
+                                    // Get the four surrounding pixel values
+                                    final double s00 = srcData[posx + posy];
+                                    final double s01 = srcData[posx + srcPixelStride + posy];
+                                    final double s10 = srcData[posx + posy + srcScanlineStride];
+                                    final double s11 = srcData[posx + srcPixelStride + posy
+                                            + srcScanlineStride];
+                                    // Perform the bilinear interpolation
+                                    final double s = InterpolationBilinear.computeValueDouble(s00, s01, s10,
+                                            s11, w00 == 0, w01 == 0, w10 == 0, w11 == 0, xfrac[i], yfrac[j], dataType, destinationNoDataDouble[k]).doubleValue();
+
+                                    // The interpolated value is saved in the destination array
+                                    dstData[dstPixelOffset] = s;
                                 }
                                 // destination pixel offset update
                                 dstPixelOffset += dstPixelStride;
@@ -2540,21 +2462,20 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     int w10 = w10index < roiDataLength ? roiDataArray[w10index] : 0;
                                     int w11 = w11index < roiDataLength ? roiDataArray[w11index] : 0;
 
-                                    if (baseIndex > roiDataLength || w00 == 0) {
+                                    if (baseIndex > roiDataLength) {
                                         dstData[dstPixelOffset] = destinationNoDataDouble[k];
                                     } else if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataDouble[k];
                                     } else {
-
-                                        boolean w00z = noData.contains(s00);
-                                        boolean w01z = noData.contains(s01);
-                                        boolean w10z = noData.contains(s10);
-                                        boolean w11z = noData.contains(s11);
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
 
                                         // The interpolated value is saved in the destination array
                                         dstData[dstPixelOffset] = InterpolationBilinear.computeValueDouble(s00, s01, s10,
-                                                s11, w00z, w01z, w10z, w11z, xfrac[i], yfrac[j],
+                                                s11, w00 == 0, w01 == 0, w10 == 0, w11 == 0, xfrac[i], yfrac[j],
                                                 dataType, destinationNoDataDouble[k]).doubleValue();
                                     }
                                     // destination pixel offset update
@@ -2589,37 +2510,30 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
                                     final int y0 = src.getY() + (posy - bandOffset)
                                             / srcScanlineStride;
 
-                                    if (roiBounds.contains(x0, y0)) {
+                                    int w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) : 0;
+                                    int w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                                    int w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) : 0;
+                                    int w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
 
-                                        int w00 = roiIter.getSample(x0, y0, 0);
-                                        int w01 = roiIter.getSample(x0 + 1, y0, 0);
-                                        int w10 = roiIter.getSample(x0, y0 + 1, 0);
-                                        int w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
+                                    if (!(w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0)) {
+                                        // Get the four surrounding pixel values
+                                        final double s00 = srcData[posx + posy];
+                                        final double s01 = srcData[posx + srcPixelStride + posy];
+                                        final double s10 = srcData[posx + posy
+                                                + srcScanlineStride];
+                                        final double s11 = srcData[posx + srcPixelStride + posy
+                                                + srcScanlineStride];
 
-                                        if (!(w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0)) {
+                                        w00 = noData.contains(s00) ? 0 : w00;
+                                        w01 = noData.contains(s01) ? 0 : w01;
+                                        w10 = noData.contains(s10) ? 0 : w10;
+                                        w11 = noData.contains(s11) ? 0 : w11;
 
-                                            // Get the four surrounding pixel values
-                                            final double s00 = srcData[posx + posy];
-                                            final double s01 = srcData[posx + srcPixelStride + posy];
-                                            final double s10 = srcData[posx + posy
-                                                    + srcScanlineStride];
-                                            final double s11 = srcData[posx + srcPixelStride + posy
-                                                    + srcScanlineStride];
+                                        // compute value
+                                        dstData[dstPixelOffset] = InterpolationBilinear.computeValueDouble(s00, s01,
+                                                s10, s11, w00 == 0, w01 == 0, w10 == 0, w11 == 0, xfrac[i],
+                                                yfrac[j], dataType, destinationNoDataDouble[k]).doubleValue();
 
-                                            boolean w00z = noData.contains(s00);
-                                            boolean w01z = noData.contains(s01);
-                                            boolean w10z = noData.contains(s10);
-                                            boolean w11z = noData.contains(s11);
-
-                                            // compute value
-                                            dstData[dstPixelOffset] = InterpolationBilinear.computeValueDouble(s00, s01,
-                                                    s10, s11, w00z, w01z, w10z, w11z, xfrac[i],
-                                                    yfrac[j], dataType, destinationNoDataDouble[k]).doubleValue();
-
-                                        } else {
-                                            // The destination no data value is saved in the destination array
-                                            dstData[dstPixelOffset] = destinationNoDataDouble[k];
-                                        }
                                     } else {
                                         // The destination no data value is saved in the destination array
                                         dstData[dstPixelOffset] = destinationNoDataDouble[k];
@@ -2640,208 +2554,9 @@ public class ScaleBilinearOpImage extends ScaleOpImage {
 
 
     /* Private method for calculate bilinear interpolation for byte, short/ushort, integer dataType */
-    private int computeValue(int s00, int s01, int s10, int s11, int w00, int w01, int w10,
+    int computeValue(int s00, int s01, int s10, int s11, int w00, int w01, int w10,
             int w11, int xfrac, int yfrac, int k) {
-
-        int s0 = 0;
-        int s1 = 0;
-        int s = 0;
-
-        long s0L = 0;
-        long s1L = 0;
-
-        // Complementary values of the fractional part
-        int xfracCompl = one - xfrac;
-        int yfracCompl = one - yfrac;
-
-        // Boolean indicating if a pixel weight is 0
-        boolean w00z = w00 == 0;
-        boolean w01z = w01 == 0;
-        boolean w10z = w10 == 0;
-        boolean w11z = w11 == 0;
-
-        // Boolean indicating if 2 same line-pixel weights are 0
-        boolean w0z = w00z && w01z;
-        boolean w1z = w10z && w11z;
-
-        if (w0z && w1z) {
-            switch (dataType) {
-            case DataBuffer.TYPE_BYTE:
-                return destinationNoDataByte[k];
-            case DataBuffer.TYPE_USHORT:
-                return destinationNoDataUShort[k];
-            case DataBuffer.TYPE_SHORT:
-                return destinationNoDataShort[k];
-            case DataBuffer.TYPE_INT:
-                return destinationNoDataInt[k];
-            }
-        }
-
-        int shift = 29 - subsampleBits;
-        // For Integer value is possible that a bitshift of "subsampleBits" could shift over the integer bit number
-        // so the samples, in this case, are expanded to Long.
-        boolean s0Long = ((s00 | s10) >>> shift == 0);
-        boolean s1Long = ((s01 | s11) >>> shift == 0);
-
-        // boolean indicating if the data type is DataBuffer.TYPE_INT
-        boolean dataINT = dataType == DataBuffer.TYPE_INT;
-        // All the possible weight combination are checked
-        if (w00z || w01z || w10z || w11z) {
-            // For integers is even considered the case when the integers are expanded to longs
-            if (dataINT) {
-
-                if (w0z) {
-                    s0L = 0;
-                } else if (w00z) {// w01 = 1
-                    s0L = s01 * xfrac;
-                } else if (w01z) {// w00 = 1
-                    s0L = s00 * xfracCompl;
-                } else {// w00 = 1 & W01 = 1
-                    if (s0Long) {
-                        if (s1Long) {
-                            s0L = (s01 - s00) * xfrac + (s00 << subsampleBits);
-                        } else {
-                            s0L = (1L * s01 - s00) * xfrac + (1L * s00 << subsampleBits);
-                        }
-                    } else {
-                        s0L = (1L * s01 - s00) * xfrac + (1L * s00 << subsampleBits);
-                    }
-                }
-
-                // lower value
-
-                if (w1z) {
-                    s1L = 0;
-                } else if (w10z) { // w11 = 1
-                    s1L = s11 * xfrac;
-                } else if (w11z) { // w10 = 1 // - (s10 * xfrac); //s10;
-                    s1L = s10 * xfracCompl;
-                } else {
-                    if (s0Long) {
-                        if (s1Long) {
-                            s1L = (s11 - s10) * xfrac + (s10 << subsampleBits);
-                        } else {
-                            s1L = (1L * s11 - s10) * xfrac + (1L * s10 << subsampleBits);
-                        }
-                    } else {
-                        s1L = (1L * s11 - s10) * xfrac + (1L * s10 << subsampleBits);
-                    }
-                }
-
-                if (w0z) {
-                    s = (int) ((s1L * yfrac + round2) >> shift2);
-                } else {
-                    if (w1z) {
-                        s = (int) ((s0L * yfracCompl + round2) >> shift2);
-                    } else {
-                        s = (int) (((s1L - s0L) * yfrac + (s0L << subsampleBits) + round2) >> shift2);
-                    }
-                }
-
-            } else {
-
-                // S00 .......... S01
-                //  .              .
-                //  .              .
-                //  .              .
-                //  .              .
-                //  .         *    .   <- yfrac
-                //  .              .
-                //  .              .
-                // S10 .......... S11
-                //
-                //            ^
-                //            |
-                //          xfrac
-
-                // bilinear interpolation does 2 interpolations along X and then interpolates
-                // the results along y.
-                // In case any of these interpolations involves a noData source pixel, 
-                // the value of the other pixel will be only used in case the frac component
-                // is nearest to that pixel. Otherwise, the result will be noData too.
-                // To give an example: in case S01 is noData, S00 will not contribute to the 
-                // output value since it is too far from the position.
-                // This avoids having shaded dark edges going out of the original valid bounds
-
-                // Whether S*1 Pixel will fully contribute if opposite S*0 pixel is nodata
-                final boolean xt1 = xfrac >= FRACTION_THRESHOLD_I;
-
-                // Whether S*0 Pixel will fully contribute if opposite S*1 pixel is nodata
-                final boolean xt0 = xfracCompl >= FRACTION_THRESHOLD_I;
-
-                // Whether Previous horizontal interpolation on S1* pixels will contribute
-                final boolean yt1 = yfrac >= FRACTION_THRESHOLD_I;
-
-                // Whether Previous horizontal interpolation on S0* pixels will contribute
-                final boolean yt0 = yfracCompl >= FRACTION_THRESHOLD_I;
-
-                // First horizontal interpolation
-                if (w0z) {
-                    s0 = 0;
-                } else if (w00z) { // w01 = 1
-                    s0 = xt1 ? s01 << FULL_WEIGHT_SHIFT : 0;
-                } else if (w01z) {// w00 = 1
-                    s0 = xt0 ? s00 << FULL_WEIGHT_SHIFT : 0;
-                } else {// w00 = 1 & W01 = 1
-                    s0 = (s01 - s00) * xfrac + (s00 << subsampleBits);
-                }
-
-                // Second horizontal interpolation
-                if (w1z) {
-                    s1 = 0;
-                } else if (w10z) { // w11 = 1
-                    s1 = xt1 ? s11 << FULL_WEIGHT_SHIFT : 0;
-                } else if (w11z) { // w10 = 1
-                    s1 = xt0 ? s10 << FULL_WEIGHT_SHIFT : 0;
-                } else {
-                    s1 = (s11 - s10) * xfrac + (s10 << subsampleBits);
-                }
-
-                // Combining threshold weights with the nodata flags
-                w00z &= xt0;
-                w01z &= xt1;
-                w10z &= xt0;
-                w11z &= xt1;
-
-                // Vertical interpolation
-                if (w0z || w00z || w01z) {
-                    s = yt1 && !w1z && !w10z && !w11z
-                            ? (((s1 << FULL_WEIGHT_SHIFT) + round2) >> shift2)
-                            : destinationNoDataInt[k];
-                } else if (w1z || w10z || w11z) {
-                    s = yt0 && !w0z && !w00z && !w01z
-                            ? (((s0 << FULL_WEIGHT_SHIFT) + round2) >> shift2)
-                            : destinationNoDataInt[k];
-                } else {
-                    s = (((s1 - s0) * yfrac + (s0 << subsampleBits) + round2) >> shift2);
-                }
-            }
-        } else {
-            // Perform the bilinear interpolation
-            if (dataINT) {
-                if (s0Long) {
-                    if (s1Long) {
-                        s0 = (s01 - s00) * xfrac + (s00 << subsampleBits);
-                        s1 = (s11 - s10) * xfrac + (s10 << subsampleBits);
-                        s = ((s1 - s0) * yfrac + (s0 << subsampleBits) + round2) >> shift2;
-                    } else {
-                        s0L = (1L * s01 - s00) * xfrac + (s00 << subsampleBits);
-                        s1L = (1L * s11 - s10) * xfrac + (s10 << subsampleBits);
-                        s = (int) (((s1L - s0L) * yfrac + (s0L << subsampleBits) + round2) >> shift2);
-                    }
-                } else {
-                    s0L = (1L * s01 - s00) * xfrac + (1L * s00 << subsampleBits);
-                    s1L = (1L * s11 - s10) * xfrac + (1L * s10 << subsampleBits);
-                    s = (int) (((s1L - s0L) * yfrac + (s0L << subsampleBits) + round2) >> shift2);
-                }
-            } else {
-                s0 = (s01 - s00) * xfrac + (s00 << subsampleBits);
-                s1 = (s11 - s10) * xfrac + (s10 << subsampleBits);
-                s = ((s1 - s0) * yfrac + (s0 << subsampleBits) + round2) >> shift2;
-            }
-        }
-
-        return s;
+        return bilinearInterpolator.computeValue(s00, s01, s10, s11, w00, w01, w10, w11, xfrac, yfrac);
     }
 
 }

--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleCRIF.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleCRIF.java
@@ -54,7 +54,7 @@ import it.geosolutions.jaiext.utilities.ImageUtilities;
  */
 public class ScaleCRIF extends CRIFImpl {
 
-    private static final float TOLERANCE = 0.01F;
+    static final float TOLERANCE = 0.01F;
 
     /** Constructor. */
     public ScaleCRIF() {

--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleDescriptor.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleDescriptor.java
@@ -16,8 +16,12 @@
 * limitations under the License.
 */
 package it.geosolutions.jaiext.scale;
-import java.awt.Rectangle;
-import java.awt.RenderingHints;
+
+import com.sun.media.jai.util.PropertyGeneratorImpl;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+import java.awt.*;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
 import java.awt.image.renderable.RenderableImage;
@@ -39,15 +43,12 @@ import javax.media.jai.operator.ConstantDescriptor;
 import javax.media.jai.registry.RenderableRegistryMode;
 import javax.media.jai.registry.RenderedRegistryMode;
 
-import it.geosolutions.jaiext.utilities.ImageLayout2;
-import it.geosolutions.jaiext.vectorbin.ROIGeometry;
-
-import com.sun.media.jai.util.PropertyGeneratorImpl;
-import com.vividsolutions.jts.geom.Geometry;
-
 import it.geosolutions.jaiext.interpolators.InterpolationBicubic;
 import it.geosolutions.jaiext.interpolators.InterpolationBilinear;
 import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.translate.TranslateIntOpImage;
+import it.geosolutions.jaiext.utilities.ImageLayout2;
+import it.geosolutions.jaiext.vectorbin.ROIGeometry;
 
 /**
  * This property generator computes the properties for the operation
@@ -130,8 +131,14 @@ class ScalePropertyGenerator extends PropertyGeneratorImpl {
 
             Rectangle dstBounds = op.getBounds();
             PlanarImage roiImage = null;
-            
-            if (interp instanceof InterpolationBilinear || interp instanceof javax.media.jai.InterpolationBilinear) {
+
+            // parallel to the ScaleCRIF, use a TranslateInt when possible
+            if (sx == 1.0F && sy == 1.0F && (Math.abs(tx - (int) tx) < ScaleCRIF.TOLERANCE)
+                    && (Math.abs(ty - (int) ty) < ScaleCRIF.TOLERANCE)) {
+                // It's an integer translate.
+                roiImage = new TranslateIntOpImage(srcROI.getAsImage(), null, (int) tx, (int) ty);
+            } else if (interp instanceof InterpolationBilinear || interp instanceof javax.media.jai.InterpolationBilinear
+                    || interp instanceof InterpolationBicubic || interp instanceof javax.media.jai.InterpolationBicubic) {
                 // Setting constant image to be scaled as a ROI
 
                 ImageLayout2 layout = new ImageLayout2();
@@ -155,23 +162,32 @@ class ScalePropertyGenerator extends PropertyGeneratorImpl {
                 // Make sure to specify tileCache, tileScheduler, tileRecyclier, by cloning hints.
                 RenderingHints scalingHints = op.getRenderingHints();
                 scalingHints.remove(JAI.KEY_IMAGE_LAYOUT);
+                scalingHints.put(JAI.KEY_BORDER_EXTENDER, extender);
 
+                boolean isBilinear = (interp instanceof InterpolationBilinear || interp instanceof javax.media.jai.InterpolationBilinear);
+                Interpolation interpParam = isBilinear
+                        ? new InterpolationBilinear(interp.getSubsampleBitsH(), null, false, 0,
+                                constantImage.getSampleModel().getDataType())
+                        : new InterpolationBicubic(interp.getSubsampleBitsH(), null, false, 0,
+                                constantImage.getSampleModel().getDataType(), false, 8);
+
+                ParameterBlock paramBlock = new ParameterBlock();
+                paramBlock.setSource(constantImage, 0);
+                paramBlock.add(Float.valueOf(sx));
+                paramBlock.add(Float.valueOf(sy));
+                paramBlock.add(Float.valueOf(tx));
+                paramBlock.add(Float.valueOf(ty));
+                paramBlock.add(interpParam);
                 if (srcROI instanceof ROIGeometry) {
                     ROIGeometry roiGeom = (ROIGeometry) srcROI;
                     Geometry geom = roiGeom.getAsGeometry();
                     if (geom != null && !geom.isEmpty()) {
-                        constantImage.setProperty("roi", srcROI);
+                        paramBlock.add(srcROI);
                     }
                 } else {
-                    constantImage.setProperty("roi", srcROI);
+                    paramBlock.add(srcROI);
                 }
-
-                InterpolationBilinear interpBilinear = new InterpolationBilinear(
-                        interp.getSubsampleBitsH(), null, false, 0,
-                        constantImage.getSampleModel().getDataType());
-
-                roiImage = new ScaleGeneralOpImage(constantImage, null, scalingHints, extender,
-                        interpBilinear, sx, sy, tx, ty, false, null, null);
+                roiImage = JAI.create("Scale", paramBlock, scalingHints);
             } else {
                 PlanarImage roiMod = srcROI.getAsImage();
                 ParameterBlock paramBlock = new ParameterBlock();

--- a/jt-scale/src/test/java/it/geosolutions/jaiext/scale/TestScale.java
+++ b/jt-scale/src/test/java/it/geosolutions/jaiext/scale/TestScale.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.awt.RenderingHints;
+import java.awt.*;
 import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
@@ -31,9 +31,11 @@ import java.awt.image.renderable.ParameterBlock;
 import java.io.IOException;
 
 import javax.media.jai.BorderExtender;
+import javax.media.jai.ImageLayout;
 import javax.media.jai.Interpolation;
 import javax.media.jai.JAI;
 import javax.media.jai.PlanarImage;
+import javax.media.jai.ROI;
 import javax.media.jai.ROIShape;
 import javax.media.jai.RenderedOp;
 import javax.media.jai.TiledImage;
@@ -451,5 +453,31 @@ public class TestScale extends TestBase {
                 assertTrue("Expected valid value but found nodata", value > 0);
             }
         }
+    }
+
+    /**
+     * Build a 4x4 image with pixels having value as the sum of their coordinates, attaches
+     * a ROI covering the 4 central pixels, and scales up by a factor of 2 with the given interpolation
+     * @param dataType
+     * @return
+     */
+    protected RenderedImage buildImageWithROI(int dataType, Interpolation interpolation, boolean useROIAccessor, Range noData) {
+        
+        int width = 4;
+        int height = 4;
+        SampleModel sm = new ComponentSampleModel(dataType, width, height, 1, width, new int[] {0});
+        TiledImage source =
+                new TiledImage(0, 0, width, height, 0, 0, sm, PlanarImage.createColorModel(sm));
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                source.setSample(x, y, 0, x + y);
+            }
+        }
+        
+        // build a ROI covering the center of the image and associate
+        ROI roi = new ROIShape(new Rectangle(1, 1, 2, 2));
+        RenderingHints hints = new RenderingHints(JAI.KEY_BORDER_EXTENDER,BorderExtender.createInstance(BorderExtender.BORDER_COPY));
+        hints.put(JAI.KEY_IMAGE_LAYOUT, new ImageLayout(0, 0, width * 2, height * 2, 0, 0, width * 2, height * 2, null, null));
+        return ScaleDescriptor.create(source, 2f, 2f, 0f, 0f, interpolation, roi, useROIAccessor, noData, new double[] {0}, hints);
     }
 }

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/interpolators/InterpolationBicubic.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/interpolators/InterpolationBicubic.java
@@ -580,14 +580,14 @@ public class InterpolationBicubic extends InterpolationTable implements Interpol
         }
         
         
-        // If The pixel is not outside the ROI
-        for (int i = 0; i < weightArrayLength; i++) {
-            for (int j = 0; j < weightArrayLength; j++) {
-                weightArray[i][j] = 1;
-
-            }
-        }
-        
+//        // If The pixel is not outside the ROI
+//        for (int i = 0; i < weightArrayLength; i++) {
+//            for (int j = 0; j < weightArrayLength; j++) {
+//                weightArray[i][j] = 1;
+//
+//            }
+//        }
+//        
         // -------------------------NO-DATA-CONTROL--------------------------------
         if (noDataRange != null) {
             switch (dataType) {

--- a/jt-utilities/src/main/java/it/geosolutions/jaiext/interpolators/InterpolationBilinear.java
+++ b/jt-utilities/src/main/java/it/geosolutions/jaiext/interpolators/InterpolationBilinear.java
@@ -17,14 +17,14 @@
 */
 package it.geosolutions.jaiext.interpolators;
 
-import it.geosolutions.jaiext.range.Range;
-
-import java.awt.Rectangle;
+import java.awt.*;
 import java.awt.image.DataBuffer;
 
 import javax.media.jai.Interpolation;
 import javax.media.jai.RasterAccessor;
 import javax.media.jai.iterator.RandomIter;
+
+import it.geosolutions.jaiext.range.Range;
 
 public class InterpolationBilinear extends Interpolation implements InterpolationNoData{
 
@@ -366,50 +366,49 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
             int x0 = src.getX() + posXlow / srcPixelStride;
             int y0 = src.getY() + (posYlow - srcBandOffset) / srcScanLineStride;
             // ROI control
-            if (roiBounds.contains(x0, y0)) {
                 switch (dataType) {
                 case DataBuffer.TYPE_BYTE:
-                    w00 = roiIter.getSample(x0, y0, 0) & 0xFF;
-                    w01 = roiIter.getSample(x0 + 1, y0, 0) & 0xFF;
-                    w10 = roiIter.getSample(x0, y0 + 1, 0) & 0xFF;
-                    w11 = roiIter.getSample(x0 + 1, y0 + 1, 0) & 0xFF;
+                    w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) & 0xFF : 0;
+                    w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) & 0xFF : 0;
+                    w10 = roiBounds.contains(x0, y0 + 1 ) ? roiIter.getSample(x0, y0 + 1, 0) & 0xFF : 0;
+                    w11 = roiBounds.contains(x0 + 1, y0 + 1) ?roiIter.getSample(x0 + 1, y0 + 1, 0) & 0xFF : 0;
                     if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                         return destinationNoData;
                     }
                     break;
                 case DataBuffer.TYPE_USHORT:
-                    w00 = roiIter.getSample(x0, y0, 0) & 0xFFFF;
-                    w01 = roiIter.getSample(x0 + 1, y0, 0) & 0xFFFF;
-                    w10 = roiIter.getSample(x0, y0 + 1, 0) & 0xFFFF;
-                    w11 = roiIter.getSample(x0 + 1, y0 + 1, 0) & 0xFFFF;
+                    w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0) &  0xFFFF : 0;
+                    w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) &  0xFFFF : 0;
+                    w10 = roiBounds.contains(x0, y0 + 1 ) ? roiIter.getSample(x0, y0 + 1, 0) &  0xFFFF : 0;
+                    w11 = roiBounds.contains(x0 + 1, y0 + 1) ?roiIter.getSample(x0 + 1, y0 + 1, 0) &  0xFFFF : 0;
                     if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                         return destinationNoData;
                     }
                     break;
                 case DataBuffer.TYPE_SHORT:
                 case DataBuffer.TYPE_INT:
-                    w00 = roiIter.getSample(x0, y0, 0);
-                    w01 = roiIter.getSample(x0 + 1, y0, 0);
-                    w10 = roiIter.getSample(x0, y0 + 1, 0);
-                    w11 = roiIter.getSample(x0 + 1, y0 + 1, 0);
+                    w00 = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0): 0;
+                    w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                    w10 = roiBounds.contains(x0, y0 + 1 ) ? roiIter.getSample(x0, y0 + 1, 0): 0;
+                    w11 = roiBounds.contains(x0 + 1, y0 + 1) ?roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
                     if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
                         return destinationNoData;
                     }
                     break;
                 case DataBuffer.TYPE_FLOAT:
-                    w00f = roiIter.getSample(x0, y0, 0);
-                    w01f = roiIter.getSample(x0 + 1, y0, 0);
-                    w10f = roiIter.getSample(x0, y0 + 1, 0);
-                    w11f = roiIter.getSample(x0 + 1, y0 + 1, 0);
+                    w00f = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0): 0;
+                    w01f = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                    w10f = roiBounds.contains(x0, y0 + 1 ) ? roiIter.getSample(x0, y0 + 1, 0): 0;
+                    w11f = roiBounds.contains(x0 + 1, y0 + 1) ?roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
                     if (w00f == 0 && w01f == 0 && w10f == 0 && w11f == 0) {
                         return destinationNoData;
                     }
                     break;
                 case DataBuffer.TYPE_DOUBLE:
-                    w00d = roiIter.getSample(x0, y0, 0);
-                    w01d = roiIter.getSample(x0 + 1, y0, 0);
-                    w10d = roiIter.getSample(x0, y0 + 1, 0);
-                    w11d = roiIter.getSample(x0 + 1, y0 + 1, 0);
+                    w00d = roiBounds.contains(x0, y0) ? roiIter.getSample(x0, y0, 0): 0;
+                    w01d = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) : 0;
+                    w10d = roiBounds.contains(x0, y0 + 1 ) ? roiIter.getSample(x0, y0 + 1, 0): 0;
+                    w11d = roiBounds.contains(x0 + 1, y0 + 1) ?roiIter.getSample(x0 + 1, y0 + 1, 0) : 0;
                     if (w00d == 0 && w01d == 0 && w10d == 0 && w11d == 0) {
                         return destinationNoData;
                     }
@@ -417,25 +416,7 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                 default:
                     break;
                 }
-            } else {
-                return destinationNoData;
-            }
         }
-
-        w00 = 1;
-        w01 = 1;
-        w10 = 1;
-        w11 = 1;
-
-        w00f = 1f;
-        w01f = 1f;
-        w10f = 1f;
-        w11f = 1f;
-
-        w00d = 1d;
-        w01d = 1d;
-        w10d = 1d;
-        w11d = 1d;
 
         // No Data Control for the 4 selected pixels.If any of these 4 pixel is NO DATA,
         // his related weight is set to 0, else it is leaved unchanged.
@@ -596,14 +577,10 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
             int x0 = coordinates[0];
             int y0 = coordinates[1];
             // ROI control
-            if (roiBounds.contains(x0, y0)) {
-                w00 = roiIter.getSample(x0, y0, 0) & 0x1;
-                w01 = roiIter.getSample(x0 + 1, y0, 0) & 0x1;
-                w10 = roiIter.getSample(x0, y0 + 1, 0) & 0x1;
-                w11 = roiIter.getSample(x0 + 1, y0 + 1, 0) & 0x1;
-            } else {
-                return black;
-            }
+            w00 = roiBounds.contains(x0, y0)  ? roiIter.getSample(x0, y0, 0) & 0x1 : 0;
+            w01 = roiBounds.contains(x0 + 1, y0) ? roiIter.getSample(x0 + 1, y0, 0) & 0x1 : 0;
+            w10 = roiBounds.contains(x0, y0 + 1) ? roiIter.getSample(x0, y0 + 1, 0) & 0x1 : 0;
+            w11 = roiBounds.contains(x0 + 1, y0 + 1) ? roiIter.getSample(x0 + 1, y0 + 1, 0) & 0x1 : 0;
         }
 
         // Calculates the interpolation for every type of data that allows binary images.
@@ -627,7 +604,7 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                 int roiDataLength = roiDataArray.length;
                 w00index = roiYOffset + sbytenum;
 
-                if (w00index > roiDataLength || (roiDataArray[w00index] >> sshift & 0x01) == 0) {
+                if (w00index > roiDataLength) {
                     return black;
                 }
 
@@ -635,10 +612,10 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                 w10index = roiYOffset + roiScanlineStride + sbytenum;
                 w11index = roiYOffset + roiScanlineStride + xNextByteNo;
 
-                w00 = w00index < roiDataLength ? roiDataArray[w00index] >> sshift & 0x01 : 0;
-                w01 = w01index < roiDataLength ? roiDataArray[w01index] >> xNextShiftNo & 0x01 : 0;
-                w10 = w10index < roiDataLength ? roiDataArray[w10index] >> sshift & 0x01 : 0;
-                w11 = w11index < roiDataLength ? roiDataArray[w11index] >> xNextShiftNo & 0x01 : 0;
+                w00 = w00index < roiDataLength ? roiDataArray[w00index] >> sshift & 0x01 : w00;
+                w01 = w01index < roiDataLength ? roiDataArray[w01index] >> xNextShiftNo & 0x01 : w01;
+                w10 = w10index < roiDataLength ? roiDataArray[w10index] >> sshift & 0x01 : w10;
+                w11 = w11index < roiDataLength ? roiDataArray[w11index] >> xNextShiftNo & 0x01 : w11;
             }
             break;
         case DataBuffer.TYPE_USHORT:
@@ -658,7 +635,7 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                 int roiDataLength = roiDataArray.length;
                 w00index = roiYOffset + sshortnum;
 
-                if (w00index > roiDataLength || (roiDataArray[w00index] >> sshift & 0x01) == 0) {
+                if (w00index > roiDataLength) {
                     return black;
                 }
 
@@ -666,10 +643,10 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                 w10index = roiYOffset + roiScanlineStride + sshortnum;
                 w11index = roiYOffset + roiScanlineStride + xNextShortNo;
 
-                w00 = w00index < roiDataLength ? roiDataArray[w00index] >> sshift & 0x01 : 0;
-                w01 = w01index < roiDataLength ? roiDataArray[w01index] >> xNextShiftNo & 0x01 : 0;
-                w10 = w10index < roiDataLength ? roiDataArray[w10index] >> sshift & 0x01 : 0;
-                w11 = w11index < roiDataLength ? roiDataArray[w11index] >> xNextShiftNo & 0x01 : 0;
+                w00 = w00index < roiDataLength ? roiDataArray[w00index] >> sshift & 0x01 : w00;
+                w01 = w01index < roiDataLength ? roiDataArray[w01index] >> xNextShiftNo & 0x01 : w01;
+                w10 = w10index < roiDataLength ? roiDataArray[w10index] >> sshift & 0x01 : w10;
+                w11 = w11index < roiDataLength ? roiDataArray[w11index] >> xNextShiftNo & 0x01 : w11;
             }
 
             break;
@@ -689,7 +666,7 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                 int roiDataLength = roiDataArray.length;
                 w00index = roiYOffset + sintnum;
 
-                if (w00index > roiDataLength || (roiDataArray[w00index] >> sshift & 0x01) == 0) {
+                if (w00index > roiDataLength) {
                     return black;
                 }
 
@@ -697,10 +674,10 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                 w10index = roiYOffset + roiScanlineStride + sintnum;
                 w11index = roiYOffset + roiScanlineStride + xNextIntNo;
 
-                w00 = w00index < roiDataLength ? roiDataArray[w00index] >> sshift & 0x01 : 0;
-                w01 = w01index < roiDataLength ? roiDataArray[w01index] >> xNextShiftNo & 0x01 : 0;
-                w10 = w10index < roiDataLength ? roiDataArray[w10index] >> sshift & 0x01 : 0;
-                w11 = w11index < roiDataLength ? roiDataArray[w11index] >> xNextShiftNo & 0x01 : 0;
+                w00 = w00index < roiDataLength ? roiDataArray[w00index] >> sshift & 0x01 : w00;
+                w01 = w01index < roiDataLength ? roiDataArray[w01index] >> xNextShiftNo & 0x01 : w01;
+                w10 = w10index < roiDataLength ? roiDataArray[w10index] >> sshift & 0x01 : w10;
+                w11 = w11index < roiDataLength ? roiDataArray[w11index] >> xNextShiftNo & 0x01 : w11;
             }
 
             break;
@@ -889,8 +866,10 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
     
     
     
-    /* Private method for calculate bilinear interpolation for byte, short/ushort, integer dataType */
-    private int computeValue(int s00, int s01, int s10, int s11, int w00, int w01, int w10,
+    /**
+     *  Calculates bilinear interpolation for byte, short/ushort, integer dataType
+     */
+    public int computeValue(int s00, int s01, int s10, int s11, int w00, int w01, int w10,
             int w11, int xfrac, int yfrac) {
 
         int s0 = 0;
@@ -931,12 +910,47 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
             // For integers is even considered the case when the integers are expanded to longs
             if (dataINT) {
 
+                // S00 .......... S01
+                //  .              .
+                //  .              .
+                //  .              .
+                //  .              .
+                //  .         *    .   <- yfrac
+                //  .              .
+                //  .              .
+                // S10 .......... S11
+                //
+                //            ^
+                //            |
+                //          xfrac
+
+                // bilinear interpolation does 2 interpolations along X and then interpolates
+                // the results along y.
+                // In case any of these interpolations involves a noData source pixel,
+                // the value of the other pixel will be only used in case the frac component
+                // is nearest to that pixel. Otherwise, the result will be noData too.
+                // To give an example: in case S01 is noData, S00 will not contribute to the
+                // output value since it is too far from the position.
+                // This avoids having shaded dark edges going out of the original valid bounds
+
+                // Whether S*1 Pixel will fully contribute if opposite S*0 pixel is nodata
+                final boolean xt1 = xfrac >= FRACTION_THRESHOLD_I;
+
+                // Whether S*0 Pixel will fully contribute if opposite S*1 pixel is nodata
+                final boolean xt0 = xfracCompl >= FRACTION_THRESHOLD_I;
+
+                // Whether Previous horizontal interpolation on S1* pixels will contribute
+                final boolean yt1 = yfrac >= FRACTION_THRESHOLD_I;
+
+                // Whether Previous horizontal interpolation on S0* pixels will contribute
+                final boolean yt0 = yfracCompl >= FRACTION_THRESHOLD_I;
+
                 if (w0z) {
                     s0L = 0;
                 } else if (w00z) {// w01 = 1
-                    s0L = s01 * xfrac;
+                    s0L = xt1 ? s01  << FULL_WEIGHT_SHIFT : 0;
                 } else if (w01z) {// w00 = 1
-                    s0L = s00 * xfracCompl;
+                    s0L = xt0 ? s00  << FULL_WEIGHT_SHIFT : 0;
                 } else {// w00 = 1 & W01 = 1
                     if (s0Long) {
                         if (s1Long) {
@@ -954,9 +968,9 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                 if (w1z) {
                     s1L = 0;
                 } else if (w10z) { // w11 = 1
-                    s1L = s11 * xfrac;
+                    s1L = xt1 ? s11 << FULL_WEIGHT_SHIFT : 0;
                 } else if (w11z) { // w10 = 1 // - (s10 * xfrac); //s10;
-                    s1L = s10 * xfracCompl;
+                    s1L = xt0 ? s10  << FULL_WEIGHT_SHIFT : 0;
                 } else {
                     if (s0Long) {
                         if (s1Long) {
@@ -969,16 +983,24 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
                     }
                 }
 
-                if (w0z) {
-                    s = (int) ((s1L * yfrac + round2) >> shift2);
-                } else {
-                    if (w1z) {
-                        s = (int) ((s0L * yfracCompl + round2) >> shift2);
-                    } else {
-                        s = (int) (((s1L - s0L) * yfrac + (s0L << subsampleBits) + round2) >> shift2);
-                    }
-                }
+                // Combining threshold weights with the nodata flags
+                w00z &= xt0;
+                w01z &= xt1;
+                w10z &= xt0;
+                w11z &= xt1;
 
+                // Vertical interpolation
+                if (w0z || w00z || w01z) {
+                    s = (int) (yt1 && !w1z && !w10z && !w11z
+                            ? (((s1L  << FULL_WEIGHT_SHIFT)  + round2) >> shift2)
+                            : destinationNoData);
+                } else if (w1z || w10z || w11z) {
+                    s = (int) (yt0 && !w0z && !w00z && !w01z
+                            ? (((s0L  << FULL_WEIGHT_SHIFT) + round2) >> shift2)
+                            : destinationNoData);
+                } else {
+                    s = (int) (((s1L - s0L) * yfrac + (s0L << subsampleBits) + round2) >> shift2);
+                }
             } else {
 
                 // S00 .......... S01
@@ -1084,73 +1106,6 @@ public class InterpolationBilinear extends Interpolation implements Interpolatio
     }
     
     
-    
-//    /* Private method for calculate bilinear interpolation for float/double dataType */
-//    private Number computeValueDouble(double s00, double s01, double s10, double s11, double w00,
-//            double w01, double w10, double w11, double xfrac, double yfrac, int dataType) {
-//
-//        double s0 = 0;
-//        double s1 = 0;
-//        double s = 0;
-//
-//        // Complementary values of the fractional part
-//        double xfracCompl = 1 - xfrac;
-//        double yfracCompl = 1 - yfrac;
-//
-//        if (w00 == 0 && w01 == 0 && w10 == 0 && w11 == 0) {
-//            return destinationNoData;
-//        }
-//
-//        if (w00 == 0 || w01 == 0 || w10 == 0 || w11 == 0) {
-//
-//            if (w00 == 0 && w01 == 0) {
-//                s0 = 0;
-//            } else if (w00 == 0) { // w01 = 1
-//                s0 = s01 * xfrac;
-//            } else if (w01 == 0) {// w00 = 1
-//                s0 = s00 * xfracCompl;// s00;
-//            } else {// w00 = 1 & W01 = 1
-//                s0 = (s01 - s00) * xfrac + s00;
-//            }
-//
-//            // lower value
-//
-//            if (w10 == 0 && w11 == 0) {
-//                s1 = 0;
-//            } else if (w10 == 0) { // w11 = 1
-//                s1 = s11 * xfrac;
-//            } else if (w11 == 0) { // w10 = 1
-//                s1 = s10 * xfracCompl;// - (s10 * xfrac); //s10;
-//            } else {
-//                s1 = (s11 - s10) * xfrac + s10;
-//            }
-//
-//            if (w00 == 0 && w01 == 0) {
-//                s = s1 * yfrac;
-//            } else {
-//                if (w10 == 0 && w11 == 0) {
-//                    s = s0 * yfracCompl;
-//                } else {
-//                    s = (s1 - s0) * yfrac + s0;
-//                }
-//            }
-//        } else {
-//
-//            // Perform the bilinear interpolation because all the weight are not 0.
-//            s0 = (s01 - s00) * xfrac + s00;
-//            s1 = (s11 - s10) * xfrac + s10;
-//            s = (s1 - s0) * yfrac + s0;
-//        }
-//
-//        // Simple conversion for float dataType.
-//        if (dataType == DataBuffer.TYPE_FLOAT) {
-//            return (float) s;
-//        } else {
-//            return s;
-//        }
-//
-//    }
-//    
     /* Private method for calculate bilinear interpolation for float/double dataType */
     public static Number computeValueDouble(double s00, double s01, double s10, double s11, boolean w00z,
             boolean w01z, boolean w10z, boolean w11z, double xfrac, double yfrac, int dataType, double destinationNoData) {

--- a/jt-utilities/src/main/java/it/geosolutions/rendered/viewer/HTMLRenderers.java
+++ b/jt-utilities/src/main/java/it/geosolutions/rendered/viewer/HTMLRenderers.java
@@ -17,9 +17,13 @@
 */
 package it.geosolutions.rendered.viewer;
 
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.imageio.ImageReadParam;
 
 
 /**
@@ -35,6 +39,7 @@ public final class HTMLRenderers
     static
     {
         renderers.add(new ArrayRenderer());
+        renderers.add(new ImageReadParamRenderer());
         //renderers.add(new ROIGeometryRenderer());
     }
 
@@ -63,7 +68,7 @@ public final class HTMLRenderers
         public String render(Object o)
         {
             int length = Array.getLength(o);
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append('[');
             for (int i = 0; i < length; i++)
             {
@@ -78,6 +83,43 @@ public final class HTMLRenderers
                 }
             }
 
+            return sb.toString();
+        }
+
+    }
+
+    /** 
+     * Renderer for ImageReadParam parameters, such as source subsampling,
+     * source region rectangle, source bands, ...
+     */
+    private static class ImageReadParamRenderer implements HTMLRenderer {
+
+        public boolean canRender(Object o) {
+            return (o != null) && ImageReadParam.class.isAssignableFrom(o.getClass());
+        }
+
+        public String render(Object o) {
+            ImageReadParam param = (ImageReadParam) o;
+            StringBuilder sb = new StringBuilder();
+            sb.append('[').append(o.getClass().toString()).append("\n");
+            int ssx = param.getSourceXSubsampling();
+            int ssy = param.getSourceYSubsampling();
+            Rectangle rect = param.getSourceRegion();
+            Point p = param.getDestinationOffset();
+            int[] bands = param.getSourceBands();
+            if (rect != null) {
+                sb.append(String.format(
+                        "    SourceRegion(Rectangle)[x:%d, y:%d, width:%d, height:%d]\n", rect.x,
+                        rect.y, rect.width, rect.height));
+            }
+            sb.append(String.format("    SourceSubsampling[ssx:%d, ssy:%d]\n", ssx, ssy));
+            if (bands != null) {
+                sb.append("    SourceBands[").append(HTMLBuilder.render(bands)).append("]\n");
+            }
+            if (p != null) {
+                sb.append(String.format("    DestinationOffset(Point)[x:%d, y:%d]", p.x, p.y));
+            }
+            sb.append("]");
             return sb.toString();
         }
 

--- a/jt-utilities/src/main/java/it/geosolutions/rendered/viewer/RenderedImageInfoPanel.java
+++ b/jt-utilities/src/main/java/it/geosolutions/rendered/viewer/RenderedImageInfoPanel.java
@@ -184,7 +184,7 @@ public class RenderedImageInfoPanel extends JPanel
         }
         else
         {
-            operationPanel.setEnabled(false);
+            operationPanel.setText("This image is not an operation");
         }
         if (showHistogram)
         {
@@ -208,6 +208,8 @@ public class RenderedImageInfoPanel extends JPanel
                         ROI roi = (ROI) object;
                         roiViewer.setImage(roi.getAsImage());
                     }
+                } else {
+                    roiViewer.setImage(null);
                 }
             } catch(Exception e) {
                 e.printStackTrace();
@@ -283,6 +285,7 @@ public class RenderedImageInfoPanel extends JPanel
         String[] properties = source.getPropertyNames();
         if (properties == null)
         {
+            propertiesPanel.setText("No properties found in this image");
             return;
         }
         Arrays.sort(properties);


### PR DESCRIPTION
* ScaleCRIF optimizes integer translation via TranslateIntOp, but does not do the same with ROI generation, #200
* ScaleBilinearOpImage is ignoring the ROI weights in caseB (only ROI) and also with noData, #204, and also ROI derived weights are thrown away before interpolation, #202
* The bilinear interpolation code is duplicated between scale and stand-alone billinear interpolator #201
* Use param block to create the scaling operation so that it benefits from caching and param viewing in the RIB, also fix the RIB display of images that are no operations
* More interpolation improvements on bilinear and bicubic for scale #203