### PR TITLE
upgrade guava to version 27.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <apache.version>2.1</apache.version>
      <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
-    <guava.version>25.1-jre</guava.version>
+    <guava.version>27.0-jre</guava.version>
     <jts.version>1.15.1</jts.version>
     <project.version>1.1-SNAPSHOT</project.version>
   </properties>


### PR DESCRIPTION
upgrade guava to version 27.0-jre - compile and test passes with jdk11 - osgeo java code sprint