### PR TITLE
checks on ROI indexes optimization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,12 +380,16 @@
       <url>http://download.osgeo.org/webdav/geotools/</url>
     </repository>
     <repository>
+      <!-- Contains snapshot and release (including third-party-dependencies)              -->
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <id>opengeo</id>
-      <name>OpenGeo Maven Repository</name>
-      <url>http://repo.opengeo.org</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <id>boundless</id>
+      <name>Boundless Maven Repository</name>
+      <url>https://repo.boundlessgeo.com/main/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Recently, an optimization to scale2 bilinear has been added, in order to reuse roi weights when moving to a pixel to the next one.
There might be the case where the source positions aren't consecutive so the optimization is resulting in some small black artifacts along some area of the ROI edges. We need to get the new ROI pixel when we can't reuse the previous pixel.