### PR TITLE
Speed up color indexer by using rect iters in place of random iters

### DIFF
--- a/jt-colorindexer/src/main/java/it/geosolutions/jaiext/colorindexer/ColorIndexerOpImage.java
+++ b/jt-colorindexer/src/main/java/it/geosolutions/jaiext/colorindexer/ColorIndexerOpImage.java
@@ -18,6 +18,7 @@
 package it.geosolutions.jaiext.colorindexer;
 
 import it.geosolutions.jaiext.iterators.RandomIterFactory;
+import it.geosolutions.jaiext.iterators.RectIterFactory;
 import it.geosolutions.jaiext.range.Range;
 import it.geosolutions.jaiext.range.RangeFactory;
 
@@ -37,7 +38,6 @@ import javax.media.jai.ROI;
 import javax.media.jai.ROIShape;
 import javax.media.jai.iterator.RandomIter;
 import javax.media.jai.iterator.RectIter;
-import javax.media.jai.iterator.RectIterFactory;
 import javax.media.jai.iterator.WritableRectIter;
 
 /**
@@ -263,7 +263,7 @@ public class ColorIndexerOpImage extends PointOpImage {
                     }
 
                     int idx = palette.getClosestIndex(r, g, b, a);
-                    dstIter.setSample(0, (byte) (idx & 0xff));
+                    dstIter.setSample((idx & 0xff));
 
                     if (x < srcMaxX - 1) {
                         srcIter.nextPixel();

--- a/jt-colorindexer/src/main/java/it/geosolutions/jaiext/colorindexer/ColorUtils.java
+++ b/jt-colorindexer/src/main/java/it/geosolutions/jaiext/colorindexer/ColorUtils.java
@@ -102,19 +102,19 @@ public final class ColorUtils {
 
     /**
      * Compares two longs, to be used in comparators
-     * 
+     *
      * @param l1
      * @param l2
      * @return
      */
     public static int compareLong(long l1, long l2) {
         long diff = l1 - l2;
-        if (diff == 0) {
-            return 0;
-        } else if (diff > 0) {
+        if (diff > 0) {
             return 1;
-        } else {
+        } else if (diff < 0) {
             return -1;
+        } else {
+            return 0;
         }
     }
 }

--- a/jt-colorindexer/src/main/java/it/geosolutions/jaiext/colorindexer/PackedHistogram.java
+++ b/jt-colorindexer/src/main/java/it/geosolutions/jaiext/colorindexer/PackedHistogram.java
@@ -19,6 +19,7 @@ package it.geosolutions.jaiext.colorindexer;
 
 import static it.geosolutions.jaiext.colorindexer.ColorUtils.*;
 import it.geosolutions.jaiext.colorindexer.ColorMap.ColorEntry;
+import it.geosolutions.jaiext.iterators.RectIterFactory;
 
 import java.awt.*;
 import java.awt.image.Raster;
@@ -27,7 +28,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import javax.media.jai.iterator.RectIter;
-import javax.media.jai.iterator.RectIterFactory;
 
 /**
  * Builds a histogram of a certain image making sure that we don't end up with too many entries. If the unique colors in the image go above
@@ -133,8 +133,8 @@ public class PackedHistogram {
         final int minY = image.getMinTileY();
         final int maxY = minY + image.getNumYTiles();
         this.shift = 0;
-        for (int x = minX; x < maxX; x++) {
-            for (int y = minY; y < maxY; y++) {
+        for (int y = minY; y < maxY; y++) {
+            for (int x = minX; x < maxX; x++) {
                 Raster tile = image.getTile(x, y);
                 shift = updateColorMap(image, tile, colorMap, shift, stepX, stepY);
             }
@@ -158,9 +158,9 @@ public class PackedHistogram {
         final int minY = Math.max(tile.getMinY(), image.getMinY());
         final int maxY = Math.min(tile.getHeight() + tile.getMinY(),
                 image.getMinY() + image.getHeight());
-        int bands = tile.getNumBands();
-        int[] pixel = new int[bands];
-        RectIter iter = RectIterFactory.create(tile, new Rectangle(minX, minY, maxX - minX, maxY - minY));
+        final int bands = tile.getNumBands();
+        final int[] pixel = new int[bands];
+        final RectIter iter = RectIterFactory.create(tile, new Rectangle(minX, minY, maxX - minX, maxY - minY));
         for (int y = minY; y < maxY; y += stepY) {
             for (int x = minX; x < maxX; x += stepX) {
                 // grab the pixel and the color
@@ -191,7 +191,7 @@ public class PackedHistogram {
                     blue = shift(blue, shift);
                     alpha = shift(alpha, shift);
                 }
-                colorMap.increment(red, green, blue, alpha);
+                colorMap.increment(red, green, blue, alpha, 1);
 
                 if (colorMap.size() > Short.MAX_VALUE) {
                     shift++;

--- a/jt-colorindexer/src/main/java/it/geosolutions/jaiext/colorindexer/PackedHistogram.java
+++ b/jt-colorindexer/src/main/java/it/geosolutions/jaiext/colorindexer/PackedHistogram.java
@@ -20,10 +20,14 @@ package it.geosolutions.jaiext.colorindexer;
 import static it.geosolutions.jaiext.colorindexer.ColorUtils.*;
 import it.geosolutions.jaiext.colorindexer.ColorMap.ColorEntry;
 
+import java.awt.*;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.util.Arrays;
 import java.util.Comparator;
+
+import javax.media.jai.iterator.RectIter;
+import javax.media.jai.iterator.RectIterFactory;
 
 /**
  * Builds a histogram of a certain image making sure that we don't end up with too many entries. If the unique colors in the image go above
@@ -156,10 +160,11 @@ public class PackedHistogram {
                 image.getMinY() + image.getHeight());
         int bands = tile.getNumBands();
         int[] pixel = new int[bands];
-        for (int x = minX; x < maxX; x += stepX) {
-            for (int y = minY; y < maxY; y += stepY) {
+        RectIter iter = RectIterFactory.create(tile, new Rectangle(minX, minY, maxX - minX, maxY - minY));
+        for (int y = minY; y < maxY; y += stepY) {
+            for (int x = minX; x < maxX; x += stepX) {
                 // grab the pixel and the color
-                tile.getPixel(x, y, pixel);
+                iter.getPixel(pixel);
                 int red, green, blue, alpha;
 
                 if (bands == 1 || bands == 2) {
@@ -195,6 +200,14 @@ public class PackedHistogram {
                 if (alpha == 0) {
                     transparentPixels = true;
                 }
+
+                if (x + stepX < maxX) {
+                    iter.jumpPixels(stepX);
+                }
+            }
+            if (y + stepY < maxY) {
+                iter.jumpLines(stepY);
+                iter.startPixels();
             }
         }
 

--- a/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterCSM.java
+++ b/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterCSM.java
@@ -1,0 +1,199 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2019 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package it.geosolutions.jaiext.iterators;
+
+import com.sun.media.jai.iterator.RectIterFallback;
+
+import java.awt.Rectangle;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+
+import javax.media.jai.PlanarImage;
+
+/**
+ */
+public abstract class RectIterCSM extends RectIterFallback {
+
+    protected final  int[] bankIndices;
+    protected final int scanlineStride;
+    protected final int pixelStride;
+    protected final int[] bandOffsets;
+    protected int[] DBOffsets;
+    protected int oldTileX;
+    protected int oldTileY;
+
+    protected int offset;
+    protected int bandOffset;
+
+    public RectIterCSM(RenderedImage im, Rectangle bounds) {
+        super(im, bounds);
+
+        ComponentSampleModel csm = (ComponentSampleModel)sampleModel;
+
+        this.scanlineStride = csm.getScanlineStride();
+        this.pixelStride = csm.getPixelStride();
+        this.bankIndices = csm.getBankIndices();
+        int[] bo = csm.getBandOffsets();
+
+        this.bandOffsets = new int[numBands + 1];
+        for (int i = 0; i < numBands; i++) {
+            bandOffsets[i] = bo[i];
+        }
+        bandOffsets[numBands] = 0;
+
+        this.DBOffsets = new int[numBands];
+
+        this.offset = (y - sampleModelTranslateY)*scanlineStride +
+                (x - sampleModelTranslateX)*pixelStride;
+        this.bandOffset = bandOffsets[0];
+    }
+
+    protected void dataBufferChanged() {}
+
+    protected void adjustBandOffsets() {
+        int[] newDBOffsets = dataBuffer.getOffsets();
+        for (int i = 0; i < numBands; i++) {
+            int bankNum = bankIndices[i];
+            bandOffsets[i] += newDBOffsets[bankNum] - DBOffsets[bankNum];
+        }
+        this.DBOffsets = newDBOffsets;
+    }
+
+    protected void setDataBuffer() {
+        // split to allow JIT to inline this method
+        if (dataBuffer == null || oldTileX != tileX || oldTileY != tileY) {
+            reallySetDataBuffer();
+        }
+    }
+
+    protected void reallySetDataBuffer() {
+        Raster tile = im.getTile(tileX, tileY);
+        this.dataBuffer = tile.getDataBuffer();
+        dataBufferChanged();
+
+        int newSampleModelTranslateX = tile.getSampleModelTranslateX();
+        int newSampleModelTranslateY = tile.getSampleModelTranslateY();
+
+        int deltaX = sampleModelTranslateX - newSampleModelTranslateX;
+        int deltaY = sampleModelTranslateY - newSampleModelTranslateY;
+
+        offset += deltaY*scanlineStride + deltaX*pixelStride;
+
+        this.sampleModelTranslateX = newSampleModelTranslateX;
+        this.sampleModelTranslateY = newSampleModelTranslateY;
+        this.oldTileX = tileX;
+        this.oldTileY = tileY;
+    }
+
+    public void startLines() {
+        offset += (bounds.y - y)*scanlineStride;
+        y = bounds.y;
+
+        tileY = startTileY;
+        setTileYBounds();
+        setDataBuffer();
+    }
+
+    public void nextLine() {
+        ++y;
+        offset += scanlineStride;
+    }
+
+    public void jumpLines(int num) {
+        int jumpY = y + num;
+        if (jumpY < bounds.y || jumpY > lastY) {
+            // Jumped outside the image.
+            throw new IndexOutOfBoundsException();
+        }
+
+        y = jumpY;
+        offset += num*scanlineStride;
+
+        if (y < prevYBoundary || y > nextYBoundary) {
+            this.tileY = PlanarImage.YToTileY(y,
+                    tileGridYOffset,
+                    tileHeight);
+            setTileYBounds();
+            setDataBuffer();
+        }
+    }
+
+    public void startPixels() {
+        offset += (bounds.x - x)*pixelStride;
+        x = bounds.x;
+
+        tileX = startTileX;
+        setTileXBounds();
+        setDataBuffer();
+    }
+
+    public void nextPixel() {
+        ++x;
+        offset += pixelStride;
+    }
+
+    public void jumpPixels(int num) {
+        int jumpX = x + num;
+        if (jumpX < bounds.x || jumpX > lastX) {
+            // Jumped outside the image.
+            throw new IndexOutOfBoundsException();
+        }
+
+        x = jumpX;
+        offset += num*pixelStride;
+
+        if (x < prevXBoundary || x > nextXBoundary) {
+            this.tileX = PlanarImage.XToTileX(x,
+                    tileGridXOffset,
+                    tileWidth);
+
+            setTileXBounds();
+            setDataBuffer();
+        }
+    }
+
+    public void startBands() {
+        b = 0;
+        bandOffset = bandOffsets[0];
+    }
+
+    public void nextBand() {
+        ++b;
+        bandOffset = bandOffsets[b];
+    }
+}

--- a/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterCSMByte.java
+++ b/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterCSMByte.java
@@ -1,0 +1,131 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2019 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package it.geosolutions.jaiext.iterators;
+import java.awt.Rectangle;
+import java.awt.image.DataBufferByte;
+import java.awt.image.RenderedImage;
+
+public class RectIterCSMByte extends RectIterCSM {
+
+    final byte[][] bankData;
+    protected byte[] bank;
+
+    public RectIterCSMByte(RenderedImage im, Rectangle bounds) {
+        super(im, bounds);
+
+        this.bankData = new byte[numBands + 1][];
+        dataBufferChanged();
+    }
+
+    protected final void dataBufferChanged() {
+        if (bankData == null) {
+            return;
+        }
+
+        byte[][] bd = ((DataBufferByte)dataBuffer).getBankData();
+        for (int i = 0; i < numBands; i++) {
+            bankData[i] = bd[bankIndices[i]];
+        }
+        bank = bankData[b];
+
+        adjustBandOffsets();
+    }
+
+    public void startBands() {
+        super.startBands();
+        bank = bankData[0];
+    }
+
+    public void nextBand() {
+        super.nextBand();
+        bank = bankData[b];
+    }
+
+    public final int getSample() {
+        return bank[offset + bandOffset] & 0xff;
+    }
+
+    public final int getSample(int b) {
+        return bankData[b][offset + bandOffsets[b]] & 0xff;
+    }
+
+    public final float getSampleFloat() {
+        return (float)(bank[offset + bandOffset] & 0xff);
+    }
+
+    public final float getSampleFloat(int b) {
+        return (float)(bankData[b][offset + bandOffsets[b]] & 0xff);
+    }
+
+    public final double getSampleDouble() {
+        return (double)(bank[offset + bandOffset] & 0xff);
+    }
+
+    public final double getSampleDouble(int b) {
+        return (double)(bankData[b][offset + bandOffsets[b]] & 0xff);
+    }
+
+    public int[] getPixel(int[] iArray) {
+        if (iArray == null) {
+            iArray = new int[numBands];
+        }
+        for (int b = 0; b < numBands; b++) {
+            iArray[b] = bankData[b][offset + bandOffsets[b]] & 0xff;
+        }
+        return iArray;
+    }
+
+    public float[] getPixel(float[] fArray) {
+        if (fArray == null) {
+            fArray = new float[numBands];
+        }
+        for (int b = 0; b < numBands; b++) {
+            fArray[b] = (float)(bankData[b][offset + bandOffsets[b]] & 0xff);
+        }
+        return fArray;
+    }
+
+    public double[] getPixel(double[] dArray) {
+        if (dArray == null) {
+            dArray = new double[numBands];
+        }
+        for (int b = 0; b < numBands; b++) {
+            dArray[b] = (double)(bankData[b][offset + bandOffsets[b]] & 0xff);
+        }
+        return dArray;
+    }
+}

--- a/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterCSMByteABGR.java
+++ b/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterCSMByteABGR.java
@@ -1,0 +1,43 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2019 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package it.geosolutions.jaiext.iterators;
+
+import java.awt.*;
+import java.awt.image.RenderedImage;
+
+public class RectIterCSMByteABGR extends RectIterCSMByte {
+
+    public RectIterCSMByteABGR(RenderedImage im, Rectangle bounds) {
+        super(im, bounds);
+    }
+
+    @Override
+    public int[] getPixel(int[] iArray) {
+        if (iArray == null) {
+            iArray = new int[numBands];
+        }
+        
+        iArray[3] = bankData[3][offset + 0] & 0xff;
+        iArray[2] = bankData[2][offset + 1] & 0xff;
+        iArray[1] = bankData[1][offset + 2] & 0xff;
+        iArray[0] = bankData[0][offset + 3] & 0xff;
+        return iArray;
+    }
+}

--- a/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterCSMByteABGRSingleBank.java
+++ b/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterCSMByteABGRSingleBank.java
@@ -1,0 +1,53 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+*    http://www.geo-solutions.it/
+*    Copyright 2019 GeoSolutions
+
+
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package it.geosolutions.jaiext.iterators;
+
+import java.awt.*;
+import java.awt.image.RenderedImage;
+
+public class RectIterCSMByteABGRSingleBank extends RectIterCSMByteABGR {
+
+    public RectIterCSMByteABGRSingleBank(RenderedImage im, Rectangle bounds) {
+        super(im, bounds);
+    }
+
+    @Override
+    public int[] getPixel(int[] iArray) {
+        if (iArray == null) {
+            iArray = new int[4];
+        }
+        
+        // these two checks help the JIT remove array boundary checks in accesses below
+        if (offset + 3 > bank.length)
+            throw new ArrayIndexOutOfBoundsException(
+                    "Max extracted offset "
+                            + (offset + 3)
+                            + " goes beyond bank size "
+                            + bank.length);
+        if (iArray.length < 4)
+            throw new ArrayIndexOutOfBoundsException(
+                    "Pixel should have 4 elements but has " + iArray.length);
+
+        iArray[3] = bank[offset + 0] & 0xff;
+        iArray[2] = bank[offset + 1] & 0xff;
+        iArray[1] = bank[offset + 2] & 0xff;
+        iArray[0] = bank[offset + 3] & 0xff;
+        return iArray;
+    }
+}

--- a/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterFactory.java
+++ b/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/RectIterFactory.java
@@ -1,0 +1,203 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2019 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package it.geosolutions.jaiext.iterators;
+import com.sun.media.jai.iterator.RectIterCSMFloat;
+import com.sun.media.jai.iterator.RectIterFallback;
+import com.sun.media.jai.iterator.WrapperRI;
+import com.sun.media.jai.iterator.WrapperWRI;
+import com.sun.media.jai.iterator.WritableRectIterCSMByte;
+import com.sun.media.jai.iterator.WritableRectIterCSMFloat;
+import com.sun.media.jai.iterator.WritableRectIterFallback;
+
+import java.awt.Rectangle;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRenderedImage;
+
+import javax.media.jai.iterator.RectIter;
+import javax.media.jai.iterator.WritableRectIter;
+
+
+/**
+ * A factory class to instantiate instances of the RectIter and
+ * WritableRectIter interfaces on sources of type Raster,
+ * RenderedImage, and WritableRenderedImage.
+ *
+ * @see RectIter
+ * @see WritableRectIter
+ */
+public class RectIterFactory {
+
+    /** Prevent this class from ever being instantiated. */
+    private RectIterFactory() {}
+
+    /**
+     * Constructs and returns an instance of RectIter suitable
+     * for iterating over the given bounding rectangle within the
+     * given RenderedImage source.  If the bounds parameter is null,
+     * the entire image will be used.
+     *
+     * @param im a read-only RenderedImage source.
+     * @param bounds the bounding Rectangle for the iterator, or null.
+     * @return a RectIter allowing read-only access to the source.
+     */
+    public static RectIter create(RenderedImage im,
+            Rectangle bounds) {
+        if (bounds == null) {
+            bounds = new Rectangle(im.getMinX(), im.getMinY(),
+                    im.getWidth(), im.getHeight());
+        }
+
+        SampleModel sm = im.getSampleModel();
+        if (sm instanceof ComponentSampleModel) {
+            switch (sm.getDataType()) {
+                case DataBuffer.TYPE_BYTE:
+                    ComponentSampleModel csm = (ComponentSampleModel) sm;
+                    int[] offsets = csm.getBandOffsets();
+                    if (offsets.length == 4 && offsets[0] == 3 && offsets[1] == 2 && offsets[2] == 1 && offsets[3] == 0) {
+                        int[] bankIndices = csm.getBankIndices();
+                        if (bankIndices.length == 4 && bankIndices[0] == 0 && bankIndices[1] == 0 && bankIndices[2] == 0 && bankIndices[3] == 0) {
+                            return new RectIterCSMByteABGRSingleBank(im, bounds);
+                        } else {
+                            return new RectIterCSMByteABGR(im, bounds);
+                        }
+                    } else {
+                        return new RectIterCSMByte(im, bounds);
+                    }
+                case DataBuffer.TYPE_SHORT:
+                    // return new RectIterCSMShort(im, bounds);
+                    break;
+                case DataBuffer.TYPE_USHORT:
+                    // return new RectIterCSMUShort(im, bounds);
+                    break;
+                case DataBuffer.TYPE_INT:
+                    // return new RectIterCSMInt(im, bounds);
+                    break;
+                case DataBuffer.TYPE_FLOAT:
+                    return new RectIterCSMFloat(im, bounds);
+                case DataBuffer.TYPE_DOUBLE:
+                    // return new RectIterCSMDouble(im, bounds);
+                    break;
+            }
+        }
+
+        return new RectIterFallback(im, bounds);
+    }
+
+    /**
+     * Constructs and returns an instance of RectIter suitable
+     * for iterating over the given bounding rectangle within the
+     * given Raster source.  If the bounds parameter is null,
+     * the entire Raster will be used.
+     *
+     * @param ras a read-only Raster source.
+     * @param bounds the bounding Rectangle for the iterator, or null.
+     * @return a RectIter allowing read-only access to the source.
+     */
+    public static RectIter create(Raster ras,
+            Rectangle bounds) {
+        RenderedImage im = new WrapperRI(ras);
+        return create(im, bounds);
+    }
+
+    /**
+     * Constructs and returns an instance of WritableRectIter suitable for
+     * iterating over the given bounding rectangle within the given
+     * WritableRenderedImage source.  If the bounds parameter is null,
+     * the entire image will be used.
+     *
+     * @param im a WritableRenderedImage source.
+     * @param bounds the bounding Rectangle for the iterator, or null.
+     * @return a WritableRectIter allowing read/write access to the source.
+     */
+    public static WritableRectIter createWritable(WritableRenderedImage im,
+            Rectangle bounds) {
+        if (bounds == null) {
+            bounds = new Rectangle(im.getMinX(), im.getMinY(),
+                    im.getWidth(), im.getHeight());
+        }
+
+        SampleModel sm = im.getSampleModel();
+        if (sm instanceof ComponentSampleModel) {
+            switch (sm.getDataType()) {
+                case DataBuffer.TYPE_BYTE:
+                    int[] offsets = ((ComponentSampleModel) sm).getBandOffsets();
+                    if (offsets.length == 1 && offsets[0] == 0) {
+                        return new WritableRectIterCSMByteIndexed(im, bounds);
+                    } else {
+                        return new WritableRectIterCSMByte(im, bounds);
+                    }
+                    
+                case DataBuffer.TYPE_SHORT:
+                    // return new WritableRectIterCSMShort(im, bounds);
+                    break;
+                case DataBuffer.TYPE_USHORT:
+                    // return new WritableRectIterCSMUShort(im, bounds);
+                    break;
+                case DataBuffer.TYPE_INT:
+                    // return new WritableRectIterCSMInt(im, bounds);
+                    break;
+                case DataBuffer.TYPE_FLOAT:
+                    return new WritableRectIterCSMFloat(im, bounds);
+                case DataBuffer.TYPE_DOUBLE:
+                    // return new WritableRectIterCSMDouble(im, bounds);
+                    break;
+            }
+        }
+
+        return new WritableRectIterFallback(im, bounds);
+    }
+
+    /**
+     * Constructs and returns an instance of WritableRectIter suitable for
+     * iterating over the given bounding rectangle within the given
+     * WritableRaster source.  If the bounds parameter is null,
+     * the entire Raster will be used.
+     *
+     * @param ras a WritableRaster source.
+     * @param bounds the bounding Rectangle for the iterator, or null.
+     * @return a WritableRectIter allowing read/write access to the source.
+     */
+    public static WritableRectIter createWritable(WritableRaster ras,
+            Rectangle bounds) {
+        WritableRenderedImage im = new WrapperWRI(ras);
+        return createWritable(im, bounds);
+    }
+}

--- a/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/WritableRectIterCSMByte.java
+++ b/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/WritableRectIterCSMByte.java
@@ -1,0 +1,92 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2019 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package it.geosolutions.jaiext.iterators;
+import java.awt.Rectangle;
+import java.awt.image.RenderedImage;
+
+import javax.media.jai.iterator.WritableRectIter;
+
+/**
+ */
+public class WritableRectIterCSMByte extends RectIterCSMByte
+        implements WritableRectIter {
+
+    public WritableRectIterCSMByte(RenderedImage im, Rectangle bounds) {
+        super(im, bounds);
+    }
+
+    public void setSample(int s) {
+        bank[offset + bandOffset] = (byte)s;
+    }
+
+    public void setSample(int b, int s) {
+        bankData[b][offset + bandOffsets[b]] = (byte)s;
+    }
+
+    public void setSample(float s) {
+        bank[offset + bandOffset] = (byte)s;
+    }
+
+    public void setSample(int b, float s) {
+        bankData[b][offset + bandOffsets[b]] = (byte)s;
+    }
+
+    public void setSample(double s) {
+        bank[offset + bandOffset] = (byte)s;
+    }
+
+    public void setSample(int b, double s) {
+        bankData[b][offset + bandOffsets[b]] = (byte)s;
+    }
+
+    public void setPixel(int[] iArray) {
+        for (int b = 0; b < numBands; b++) {
+            bankData[b][offset + bandOffsets[b]] = (byte)iArray[b];
+        }
+    }
+
+    public void setPixel(float[] fArray) {
+        for (int b = 0; b < numBands; b++) {
+            bankData[b][offset + bandOffsets[b]] = (byte)fArray[b];
+        }
+    }
+
+    public void setPixel(double[] dArray) {
+        for (int b = 0; b < numBands; b++) {
+            bankData[b][offset + bandOffsets[b]] = (byte)dArray[b];
+        }
+    }
+}

--- a/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/WritableRectIterCSMByteIndexed.java
+++ b/jt-iterators/src/main/java/it/geosolutions/jaiext/iterators/WritableRectIterCSMByteIndexed.java
@@ -1,0 +1,43 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2019 GeoSolutions
+
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package it.geosolutions.jaiext.iterators;
+
+import java.awt.*;
+import java.awt.image.RenderedImage;
+
+public class WritableRectIterCSMByteIndexed extends WritableRectIterCSMByte {
+    
+    public WritableRectIterCSMByteIndexed(RenderedImage im, Rectangle bounds) {
+        super(im, bounds);
+    }
+
+    @Override
+    public void setSample(int s) {
+        bank[offset] = (byte) s;
+    }
+
+    @Override
+    public void setSample(int b, int s) {
+        if (b != 0) {
+            throw new ArrayIndexOutOfBoundsException("Only legal value for band is zero");
+        }
+        bank[offset] = (byte) s;
+    }
+}


### PR DESCRIPTION
With a simple benchmark the production time of quantized images goes down by 12% with this change.

```
package it.geosolutions.jaiext.colorindexer;

import java.awt.*;
import java.awt.image.BufferedImage;
import java.awt.image.RenderedImage;
import java.util.ArrayList;
import java.util.List;
import java.util.concurrent.ExecutionException;
import java.util.concurrent.ExecutorService;
import java.util.concurrent.Executors;
import java.util.concurrent.Future;

import javax.media.jai.ROIShape;

import it.geosolutions.jaiext.JAIExt;

public class QuantizerBenchmark {

    static final int LOOPS = 2000;
    public static final int THREADS = 16;

    public static void main(String[] args) throws ExecutionException, InterruptedException {
        JAIExt.initJAIEXT();
        
        // Testing color indexing with ROI
        // build a transparent image
        BufferedImage image = new BufferedImage(256, 256, BufferedImage.TYPE_4BYTE_ABGR);
        Graphics g = image.getGraphics();
        g.setColor(Color.WHITE);
        g.fillRect(0, 0, 10, 10);
        g.setColor(Color.RED);
        g.fillRect(10, 0, 10, 10);
        g.setColor(Color.BLUE);
        g.fillRect(20, 0, 10, 10);
        g.setColor(Color.GREEN);
        g.fillRect(30, 0, 10, 10);
        g.dispose();

        ExecutorService executors = Executors.newFixedThreadPool(THREADS);

        List<Future<?>> futures = new ArrayList<>();
        long start = System.currentTimeMillis();
        for (int i = 0; i < THREADS; i++) {
            Future<?> future =
                    executors.submit(
                            new Runnable() {
                                @Override
                                public void run() {
                                    for (int j = 0; j < LOOPS; j++) {
                                        // palette and force data extraction
                                        RenderedImage indexed =
                                                quantize(
                                                        image,
                                                        null);
                                        indexed.getData();
                                        System.out.print(".");
                                    }

                                    
                                }
                            });
            futures.add(future);
        }
        for (Future<?> future : futures) {
            future.get();
        }
        long end = System.currentTimeMillis();
        System.out.println("Elapsed: " + (end - start) / 1000.0);
        executors.shutdown();
    }

    private static RenderedImage quantize(BufferedImage image, ROIShape roiShape) {
        Quantizer q = new Quantizer(256);
        ColorIndexer indexer = q.buildColorIndexer(image);
        RenderedImage indexed =
                ColorIndexerDescriptor.create(image, indexer, roiShape, null, null, null);
        return indexed;
    }
}
```

Wondering if further speedups could be achieved by using a raster accessor, or by setting up a specialized rect iter (most of the time is now spent in the iterator getPixel call:

![Selezione_875](https://user-images.githubusercontent.com/325433/63151765-811edc00-c00a-11e9-914c-695516f0d73c.png)
