### PR TITLE
#260 Capability to calculate percentages in Classification

### DIFF
--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/ClassBreaksDescriptor.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/ClassBreaksDescriptor.java
@@ -56,6 +56,7 @@ public class ClassBreaksDescriptor extends OperationDescriptorImpl {
     static final int NODATA_ARG = 7;
     static final int HISTOGRAM_ARG = 8;
     static final int HISTOGRAM_BINS = 9;
+    static final int PERCENTAGES_ARG = 10;
 
     static String[] paramNames =
             new String[] {
@@ -68,7 +69,8 @@ public class ClassBreaksDescriptor extends OperationDescriptorImpl {
                 "yPeriod",
                 "noData",
                 "histogram",
-                "histogramBins"
+                "histogramBins",
+                "percentages"
             };
 
     static final Class<?>[] paramClasses = {
@@ -81,7 +83,8 @@ public class ClassBreaksDescriptor extends OperationDescriptorImpl {
         Integer.class,
         Double.class,
         Boolean.class,
-        Integer.class
+        Integer.class,
+        Boolean.class
     };
 
     static final Object[] paramDefaults = {
@@ -94,7 +97,8 @@ public class ClassBreaksDescriptor extends OperationDescriptorImpl {
         1,
         null,
         false,
-        256
+        256,
+        false
     };
 
     public ClassBreaksDescriptor() {

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/ClassBreaksOpImage.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/ClassBreaksOpImage.java
@@ -39,6 +39,7 @@ import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
 import java.util.LinkedList;
 import java.util.ListIterator;
+import java.util.function.Predicate;
 
 import javax.media.jai.PixelAccessor;
 import javax.media.jai.ROI;
@@ -60,6 +61,9 @@ public abstract class ClassBreaksOpImage extends StatisticsOpImage {
     /* no data value */
     protected Double noData;
 
+    /* compute percentages */
+    protected Boolean percentages;
+
     public ClassBreaksOpImage(
             RenderedImage image,
             Integer numClasses,
@@ -70,7 +74,8 @@ public abstract class ClassBreaksOpImage extends StatisticsOpImage {
             Integer yStart,
             Integer xPeriod,
             Integer yPeriod,
-            Double noData) {
+            Double noData,
+            Boolean percentages) {
 
         super(image, roi, xStart, yStart, xPeriod, yPeriod);
 
@@ -78,6 +83,7 @@ public abstract class ClassBreaksOpImage extends StatisticsOpImage {
         this.extrema = extrema;
         this.bands = bands;
         this.noData = noData;
+        this.percentages=percentages;
     }
 
     @Override
@@ -238,4 +244,6 @@ public abstract class ClassBreaksOpImage extends StatisticsOpImage {
         int t = (pos - start) % Period;
         return t == 0 ? pos : pos + (Period - t);
     }
+
+
 }

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/ClassBreaksRIF.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/ClassBreaksRIF.java
@@ -32,23 +32,14 @@
  */
 package it.geosolutions.jaiext.classbreaks;
 
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.BAND_ARG;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.EXTREMA_ARG;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.HISTOGRAM_ARG;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.HISTOGRAM_BINS;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.METHOD_ARG;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.NODATA_ARG;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.NUM_CLASSES_ARG;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.ROI_ARG;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.X_PERIOD_ARG;
-import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.Y_PERIOD_ARG;
-
 import java.awt.*;
 import java.awt.image.RenderedImage;
 import java.awt.image.renderable.ParameterBlock;
 
 import javax.media.jai.CRIFImpl;
 import javax.media.jai.ROI;
+
+import static it.geosolutions.jaiext.classbreaks.ClassBreaksDescriptor.*;
 
 /**
  * RIF for the ClassBreaks operation.
@@ -81,6 +72,7 @@ public class ClassBreaksRIF extends CRIFImpl {
         Integer xPeriod = pb.getIntParameter(X_PERIOD_ARG);
         Integer yPeriod = pb.getIntParameter(Y_PERIOD_ARG);
         Double noData = (Double) pb.getObjectParameter(NODATA_ARG);
+        Boolean percentages = (Boolean) pb.getObjectParameter(PERCENTAGES_ARG);
         Boolean histogram = false;
         if (pb.getNumParameters() >= 9) {
             histogram = (Boolean) pb.getObjectParameter(HISTOGRAM_ARG);
@@ -93,7 +85,7 @@ public class ClassBreaksRIF extends CRIFImpl {
             case EQUAL_INTERVAL:
                 return new EqualIntervalBreaksOpImage(
                         src, numBins, extrema, roi, bands, xStart, yStart, xPeriod, yPeriod,
-                        noData);
+                        noData, percentages);
             case QUANTILE:
                 if (histogram) {
                     return new QuantileBreaksHistogramOpImage(
@@ -107,11 +99,12 @@ public class ClassBreaksRIF extends CRIFImpl {
                             xPeriod,
                             yPeriod,
                             noData,
-                            histogramBins);
+                            histogramBins,
+                            percentages);
                 } else {
                     return new QuantileBreaksOpImage(
                             src, numBins, extrema, roi, bands, xStart, yStart, xPeriod, yPeriod,
-                            noData);
+                            noData, percentages);
                 }
             case NATURAL_BREAKS:
                 if (histogram) {
@@ -126,11 +119,12 @@ public class ClassBreaksRIF extends CRIFImpl {
                             xPeriod,
                             yPeriod,
                             noData,
-                            histogramBins);
+                            histogramBins,
+                            percentages);
                 } else {
                     return new NaturalBreaksOpImage(
                             src, numBins, extrema, roi, bands, xStart, yStart, xPeriod, yPeriod,
-                            noData);
+                            noData, percentages);
                 }
             default:
                 throw new IllegalArgumentException(method.name());

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/ClassPercentagesManager.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/ClassPercentagesManager.java
@@ -1,0 +1,121 @@
+package it.geosolutions.jaiext.classbreaks;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * This class gathers method for percentages' computation for natural breaks,
+ * quantile and equal interval classifications
+ */
+public class ClassPercentagesManager {
+
+
+    //Quantile
+    public double[] getPercentages(Map<Double, Integer> data, List<Double> breaks, double nValues, int numClasses) {
+        double[] percentages = new double[numClasses];
+        Set<Double> keys = data.keySet();
+        for (int i = 0; i < numClasses; i++) {
+            double current = breaks.get(i);
+            double next = breaks.get(i + 1);
+            boolean last = numClasses == i + 1;
+            double classMembers;
+            if (last) {
+                classMembers = getClassMembersCount(data, keys, v -> v.doubleValue() >= current
+                        && v.doubleValue() <= next);
+            } else {
+                classMembers = getClassMembersCount(data, keys, v -> v.doubleValue() >= current
+                        && v.doubleValue() < next);
+            }
+            percentages[i] = (classMembers / nValues) * 100;
+        }
+        return percentages;
+
+    }
+
+    private int getClassMembersCount(Map<Double, Integer> data, Set<Double> keys, Predicate<Double> predicate) {
+        int classMembersCount = 0;
+        for (Double key : keys) {
+            if (predicate.test(key)) {
+                classMembersCount += data.get(key);
+            }
+        }
+        return classMembersCount;
+    }
+
+
+    // histogram natural breaks
+    public double[] getPercentages(List<HistogramClassification.Bucket> buckets,
+                                   Double[] breaks, int numClasses) {
+        double[] percentages = new double[numClasses];
+        int totalSize = 0;
+        for (int i = 0; i < buckets.size(); i++) {
+            totalSize += buckets.get(i).getCount();
+        }
+        int bucketSize = buckets.size();
+        for (int i = 0; i < numClasses; i++) {
+            double current = breaks[i];
+            double next = breaks[i + 1];
+            boolean last = numClasses == i + 1;
+            double classMembers;
+            if (last) {
+                classMembers = getClassMembersCount(bucketSize, b -> b.getMax() >= current
+                        && b.getMax() <= next, buckets);
+            } else if (i == 0) {
+                classMembers = getClassMembersCount(bucketSize, b -> b.getMin() >= current
+                        && b.getMin() < next, buckets);
+            } else {
+                classMembers = getClassMembersCount(bucketSize, b -> b.getAverage() >= current
+                        && b.getAverage() < next, buckets);
+            }
+            percentages[i] = (classMembers / totalSize) * 100;
+        }
+        return percentages;
+    }
+
+    private double getClassMembersCount(int bucketSize, Predicate<HistogramClassification.Bucket> predicate, List<HistogramClassification.Bucket> buckets) {
+        int classMembers = 0;
+        for (int i = 0; i < bucketSize; i++) {
+            HistogramClassification.Bucket b = buckets.get(i);
+            if (predicate.test(b)) {
+                classMembers += b.getCount();
+            }
+        }
+        return classMembers;
+    }
+
+
+    // Natural Breaks and Equal Interval
+    public double[] getPercentages(List<Double> data, Double[] breaks,
+                                   double totalSize, int numClasses) {
+        double[] percentages = new double[numClasses];
+        for (int i = 0; i < numClasses; i++) {
+            double current = breaks[i];
+            double next = breaks[i + 1];
+            boolean last = numClasses == i + 1;
+            double classMembers;
+            if (last) {
+                classMembers = getClassMembersCount(v -> v.doubleValue() >= current
+                        && v.doubleValue() <= next, data);
+            } else {
+                classMembers = getClassMembersCount(v -> v.doubleValue() >= current
+                        && v.doubleValue() < next, data);
+            }
+            percentages[i] = (classMembers / totalSize) * 100;
+        }
+        return percentages;
+    }
+
+
+    private double getClassMembersCount(Predicate<Double> predicate, List<Double> values) {
+        int classMembers = 0;
+        for (int i = 0; i < values.size(); i++) {
+            if (predicate.test(values.get(i))) {
+                classMembers++;
+            }
+        }
+        return classMembers;
+    }
+
+}

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/Classification.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/Classification.java
@@ -49,6 +49,8 @@ public class Classification {
     /** min/max */
     Double[] min, max;
 
+    double [] percentages;
+
     public Classification(ClassificationMethod method, int numBands) {
         this.method = method;
         this.breaks = new Double[numBands][];
@@ -82,6 +84,14 @@ public class Classification {
 
     public void setMax(int b, Double max) {
         this.max[b] = max;
+    }
+
+    public double[] getPercentages() {
+        return percentages;
+    }
+
+    public void setPercentages(double[] percentages) {
+        this.percentages = percentages;
     }
 
     public void print() {

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/EqualIntervalBreaksOpImage.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/EqualIntervalBreaksOpImage.java
@@ -32,10 +32,9 @@
  */
 package it.geosolutions.jaiext.classbreaks;
 
+import javax.media.jai.ROI;
 import java.awt.image.RenderedImage;
 import java.util.List;
-
-import javax.media.jai.ROI;
 
 /** Classification op for the equal interval method. */
 public class EqualIntervalBreaksOpImage extends ClassBreaksOpImage {

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalBreaksHistogramOpImage.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalBreaksHistogramOpImage.java
@@ -32,12 +32,11 @@
  */
 package it.geosolutions.jaiext.classbreaks;
 
-import java.awt.image.RenderedImage;
-import java.util.List;
+import it.geosolutions.jaiext.classbreaks.HistogramClassification.Bucket;
 
 import javax.media.jai.ROI;
-
-import it.geosolutions.jaiext.classbreaks.HistogramClassification.Bucket;
+import java.awt.image.RenderedImage;
+import java.util.List;
 
 /** Classification op for the natural breaks method. */
 public class NaturalBreaksHistogramOpImage extends ClassBreaksOpImage {
@@ -55,8 +54,9 @@ public class NaturalBreaksHistogramOpImage extends ClassBreaksOpImage {
             Integer xPeriod,
             Integer yPeriod,
             Double noData,
-            int numBins) {
-        super(image, numClasses, extrema, roi, bands, xStart, yStart, xPeriod, yPeriod, noData);
+            int numBins,
+            Boolean percentages) {
+        super(image, numClasses, extrema, roi, bands, xStart, yStart, xPeriod, yPeriod, noData, percentages);
         this.numBins = numBins;
     }
 
@@ -166,5 +166,13 @@ public class NaturalBreaksHistogramOpImage extends ClassBreaksOpImage {
         }
         breaks[0] = buckets.get(0).getMin();
         hc.setBreaks(band, breaks);
+        if (percentages.booleanValue()) {
+            int actualClassNumber =  k>breaks.length?breaks.length-1:k;
+            ClassPercentagesManager percentagesManager = new ClassPercentagesManager();
+            double [] percentages = percentagesManager.getPercentages(buckets, breaks, actualClassNumber);
+            hc.setPercentages(percentages);
+        }
     }
+
+
 }

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalBreaksHistogramOpImage.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalBreaksHistogramOpImage.java
@@ -36,9 +36,14 @@ import it.geosolutions.jaiext.classbreaks.HistogramClassification.Bucket;
 
 import javax.media.jai.ROI;
 import java.awt.image.RenderedImage;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.TreeSet;
 
-/** Classification op for the natural breaks method. */
+/**
+ * Classification op for the natural breaks method.
+ */
 public class NaturalBreaksHistogramOpImage extends ClassBreaksOpImage {
 
     int numBins;
@@ -77,15 +82,16 @@ public class NaturalBreaksHistogramOpImage extends ClassBreaksOpImage {
 
         final int k = numClasses;
         final int m = buckets.size();
-
+        TreeSet<Double> breaks = new TreeSet<Double>();
         if (k >= m) {
+            Double[] arrBreaks = new Double[m + 1];
             // just return all the values
-            Double[] breaks = new Double[m + 1];
             for (int i = 0; i < m; i++) {
-                breaks[i] = buckets.get(i).getMin();
+                arrBreaks[i] = buckets.get(i).getMin();
             }
-            breaks[m] = buckets.get(m - 1).getMax();
-            c.setBreaks(band, breaks);
+            arrBreaks[m] = buckets.get(m - 1).getMax();
+            c.setBreaks(band, arrBreaks);
+            setPercentages(k, arrBreaks.length, buckets, Arrays.asList(arrBreaks), c);
             return;
         }
 
@@ -153,23 +159,26 @@ public class NaturalBreaksHistogramOpImage extends ClassBreaksOpImage {
             work[i][1] = var;
         }
 
-        Double[] breaks = new Double[k + 1];
-
         // go through matrix and extract class breaks
         int ik = m - 1;
-        breaks[k] = buckets.get(ik).getMax();
+        breaks.add(buckets.get(ik).getMax());
         for (int j = k; j >= 2; j--) {
             int id =
                     (int) iwork[ik][j] - 1; // subtract one as we want inclusive breaks on the left?
-            breaks[j - 1] = buckets.get(id).getAverage();
+            breaks.add(buckets.get(id).getAverage());
             ik = (int) iwork[ik][j] - 1;
         }
-        breaks[0] = buckets.get(0).getMin();
-        hc.setBreaks(band, breaks);
+        breaks.add(buckets.get(0).getMin());
+        int breaksSize = breaks.size();
+        hc.setBreaks(band, breaks.toArray(new Double[breaksSize]));
+        setPercentages(k, breaksSize, buckets, new ArrayList<>(breaks), hc);
+    }
+
+    private void setPercentages(int k, int breaksSize, List<Bucket> buckets, List<Double> breaks, Classification hc) {
         if (percentages.booleanValue()) {
-            int actualClassNumber =  k>breaks.length?breaks.length-1:k;
+            int actualClassNumber = k >= breaksSize ? breaksSize - 1 : k;
             ClassPercentagesManager percentagesManager = new ClassPercentagesManager();
-            double [] percentages = percentagesManager.getPercentages(buckets, breaks, actualClassNumber);
+            double[] percentages = percentagesManager.getPercentages(buckets, new ArrayList<>(breaks), actualClassNumber);
             hc.setPercentages(percentages);
         }
     }

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalBreaksOpImage.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalBreaksOpImage.java
@@ -32,11 +32,10 @@
  */
 package it.geosolutions.jaiext.classbreaks;
 
+import javax.media.jai.ROI;
 import java.awt.image.RenderedImage;
 import java.util.Collections;
 import java.util.List;
-
-import javax.media.jai.ROI;
 
 /** Classification op for the natural breaks method. */
 public class NaturalBreaksOpImage extends ClassBreaksOpImage {
@@ -51,8 +50,9 @@ public class NaturalBreaksOpImage extends ClassBreaksOpImage {
             Integer yStart,
             Integer xPeriod,
             Integer yPeriod,
-            Double noData) {
-        super(image, numClasses, extrema, roi, bands, xStart, yStart, xPeriod, yPeriod, noData);
+            Double noData,
+            Boolean percentages) {
+        super(image, numClasses, extrema, roi, bands, xStart, yStart, xPeriod, yPeriod, noData, percentages);
     }
 
     @Override
@@ -159,5 +159,10 @@ public class NaturalBreaksOpImage extends ClassBreaksOpImage {
         }
         breaks[0] = data.get(0);
         nc.setBreaks(band, breaks);
+        if (percentages.booleanValue()) {
+            ClassPercentagesManager percentagesManager = new ClassPercentagesManager();
+            double [] percentages = percentagesManager.getPercentages(data, breaks, m, k);
+            nc.setPercentages(percentages);
+        }
     }
 }

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalBreaksOpImage.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalBreaksOpImage.java
@@ -36,8 +36,11 @@ import javax.media.jai.ROI;
 import java.awt.image.RenderedImage;
 import java.util.Collections;
 import java.util.List;
+import java.util.TreeSet;
 
-/** Classification op for the natural breaks method. */
+/**
+ * Classification op for the natural breaks method.
+ */
 public class NaturalBreaksOpImage extends ClassBreaksOpImage {
 
     public NaturalBreaksOpImage(
@@ -84,8 +87,10 @@ public class NaturalBreaksOpImage extends ClassBreaksOpImage {
         final int m = data.size();
 
         if (k >= m) {
+            Double[] breaks = data.toArray(new Double[data.size()]);
             // just return all the values
-            c.setBreaks(band, data.toArray(new Double[data.size()]));
+            c.setBreaks(band, breaks);
+            setPercentages(data, breaks, m, k, c);
             return;
         }
 
@@ -146,22 +151,28 @@ public class NaturalBreaksOpImage extends ClassBreaksOpImage {
             work[i][1] = var;
         }
 
-        Double[] breaks = new Double[k + 1];
+        TreeSet<Double> breaks = new TreeSet<>();
 
         // go through matrix and extract class breaks
         int ik = m - 1;
-        breaks[k] = data.get(ik);
+        breaks.add(data.get(ik));
         for (int j = k; j >= 2; j--) {
             int id = (int) iwork[ik][j] - 1; // subtract one as we want inclusive breaks on the
             // left?
-            breaks[j - 1] = data.get(id);
+            breaks.add(data.get(id));
             ik = (int) iwork[ik][j] - 1;
         }
-        breaks[0] = data.get(0);
-        nc.setBreaks(band, breaks);
+        breaks.add(data.get(0));
+        Double[] arrBreaks = breaks.toArray(new Double[breaks.size()]);
+        nc.setBreaks(band, arrBreaks);
+        setPercentages(data, arrBreaks, m, k, nc);
+    }
+
+    private void setPercentages(List<Double> data, Double[] breaks, int m, int k, Classification nc) {
         if (percentages.booleanValue()) {
             ClassPercentagesManager percentagesManager = new ClassPercentagesManager();
-            double [] percentages = percentagesManager.getPercentages(data, breaks, m, k);
+            int actualClassNumber = k > breaks.length ? breaks.length - 1 : k;
+            double[] percentages = percentagesManager.getPercentages(data, breaks, m, actualClassNumber);
             nc.setPercentages(percentages);
         }
     }

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalClassification.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/NaturalClassification.java
@@ -48,6 +48,14 @@ public class NaturalClassification extends Classification {
         }
     }
 
+    public NaturalClassification(ClassificationMethod method, int numBands) {
+        super(method, numBands);
+        values = new List[numBands];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = new ArrayList<>();
+        }
+    }
+
     public void count(double value, int band) {
         values[band].add(value);
     }

--- a/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/QuantileBreaksHistogramOpImage.java
+++ b/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/QuantileBreaksHistogramOpImage.java
@@ -37,7 +37,10 @@ import it.geosolutions.jaiext.classbreaks.HistogramClassification.Bucket;
 
 import javax.media.jai.ROI;
 import java.awt.image.RenderedImage;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeSet;
 
 /**
  * Classification op for the quantile method, using histograms instead of a fully developed list of
@@ -111,12 +114,8 @@ public class QuantileBreaksHistogramOpImage extends ClassBreaksOpImage {
     }
 
     private double[] getPercentages(List<Double> tBreaks, List<Bucket> buckets, int nvalues, int numClasses) {
-        Map<Double, Integer> values = new HashMap<>();
-        for (Bucket b : buckets) {
-            values.put(b.getMin(), b.getCount());
-        }
         ClassPercentagesManager percentagesManager = new ClassPercentagesManager();
-        return percentagesManager.getPercentages(values, tBreaks, nvalues, numClasses);
+        return percentagesManager.getPercentages(buckets, tBreaks, numClasses);
     }
 
 }

--- a/jt-classbreaks/src/test/java/it/geosolutions/jaiext/classbreaks/ClassBreaksOpImageTest.java
+++ b/jt-classbreaks/src/test/java/it/geosolutions/jaiext/classbreaks/ClassBreaksOpImageTest.java
@@ -42,6 +42,7 @@ import javax.media.jai.RenderedOp;
 import javax.media.jai.operator.ExtremaDescriptor;
 import java.awt.*;
 import java.awt.image.RenderedImage;
+import java.util.stream.DoubleStream;
 
 import static org.junit.Assert.*;
 
@@ -231,6 +232,29 @@ public class ClassBreaksOpImageTest extends TestBase {
         pb.setParameter("numClasses", 4);
         pb.setParameter("extrema", getExtrema(image));
         pb.setParameter("histogram", true);
+        pb.setParameter("histogramBins", 4);
+        pb.setParameter("percentages",true);
+        RenderedImage op  = JAI.create("ClassBreaks", pb, null);
+        Classification classification =
+                (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification);
+        double[] percentages = classification.getPercentages();
+        assertEquals(3, percentages.length);
+        assertTrue(Math.floor(percentages[0])==56.0);
+        assertTrue(percentages[1]==31.25);
+        assertTrue(percentages[2]==12.5);
+    }
+
+    @Test
+    public void testNaturalBreaksWithPercentagesMoreClassesThanIntervals() throws Exception {
+        RenderedImage image = createImage();
+
+        ParameterBlockJAI pb = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb.addSource(image);
+        pb.setParameter("method", ClassificationMethod.NATURAL_BREAKS);
+        pb.setParameter("numClasses", 11);
+        pb.setParameter("extrema", getExtrema(image));
+        pb.setParameter("histogram", true);
         pb.setParameter("histogramBins", 100);
         pb.setParameter("percentages",true);
         RenderedImage op  = JAI.create("ClassBreaks", pb, null);
@@ -238,11 +262,40 @@ public class ClassBreaksOpImageTest extends TestBase {
                 (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
         assertNotNull(classification);
         double[] percentages = classification.getPercentages();
-        assertEquals(4, percentages.length);
-        assertTrue(percentages[0]==18.75);
-        assertTrue(percentages[1]==43.75);
-        assertTrue(percentages[2]==12.5);
-        assertTrue(percentages[3]==25.0);
+        assertEquals(6, percentages.length);
+        assertTrue(percentages[0]==12.5);
+        assertTrue(percentages[1]==18.75);
+        assertTrue(percentages[2]==18.75);
+        assertTrue(percentages[3]==12.5);
+        assertTrue(percentages[4]==12.5);
+        assertTrue(percentages[5]==25.0);
+    }
+
+
+    @Test
+    public void testNaturalBreaksHistogramWithPercentagesMoreClassesThanIntervals() throws Exception {
+        RenderedImage image = createImage();
+
+        ParameterBlockJAI pb = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb.addSource(image);
+        pb.setParameter("method", ClassificationMethod.NATURAL_BREAKS);
+        pb.setParameter("numClasses", 11);
+        pb.setParameter("extrema", getExtrema(image));
+        pb.setParameter("histogram", true);
+        pb.setParameter("histogramBins", 100);
+        pb.setParameter("percentages",true);
+        RenderedImage op  = JAI.create("ClassBreaks", pb, null);
+        Classification classification =
+                (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification);
+        double[] percentages = classification.getPercentages();
+        assertEquals(6, percentages.length);
+        assertTrue(percentages[0]==12.5);
+        assertTrue(percentages[1]==18.75);
+        assertTrue(percentages[2]==18.75);
+        assertTrue(percentages[3]==12.5);
+        assertTrue(percentages[4]==12.5);
+        assertTrue(percentages[5]==25.0);
     }
 
     @Test

--- a/jt-classbreaks/src/test/java/it/geosolutions/jaiext/classbreaks/ClassBreaksOpImageTest.java
+++ b/jt-classbreaks/src/test/java/it/geosolutions/jaiext/classbreaks/ClassBreaksOpImageTest.java
@@ -32,23 +32,18 @@
  */
 package it.geosolutions.jaiext.classbreaks;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
+import it.geosolutions.jaiext.testclasses.TestBase;
+import it.geosolutions.jaiext.utilities.ImageUtilities;
 import org.junit.Test;
-
-import java.awt.*;
-import java.awt.image.RenderedImage;
-import java.util.Arrays;
 
 import javax.media.jai.JAI;
 import javax.media.jai.ParameterBlockJAI;
 import javax.media.jai.RenderedOp;
 import javax.media.jai.operator.ExtremaDescriptor;
+import java.awt.*;
+import java.awt.image.RenderedImage;
 
-import it.geosolutions.jaiext.JAIExt;
-import it.geosolutions.jaiext.testclasses.TestBase;
-import it.geosolutions.jaiext.utilities.ImageUtilities;
+import static org.junit.Assert.*;
 
 public class ClassBreaksOpImageTest extends TestBase {
 
@@ -202,6 +197,159 @@ public class ClassBreaksOpImageTest extends TestBase {
         assertEquals(16, breaks[2].doubleValue(), EPS);
         assertEquals(26, breaks[3].doubleValue(), EPS);
         assertEquals(53, breaks[4].doubleValue(), EPS);
+    }
+
+
+    @Test
+    public void testNaturalBreaksWithPercentages() throws Exception {
+        RenderedImage image = createImage();
+
+        ParameterBlockJAI pb = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb.addSource(image);
+        pb.setParameter("method", ClassificationMethod.NATURAL_BREAKS);
+        pb.setParameter("numClasses", 4);
+        pb.setParameter("percentages",true);
+        RenderedImage op  = JAI.create("ClassBreaks", pb, null);
+        Classification classification =
+                (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification);
+        double[] percentages = classification.getPercentages();
+        assertEquals(4, percentages.length);
+        assertTrue(percentages[0]==18.75);
+        assertTrue(percentages[1]==43.75);
+        assertTrue(percentages[2]==12.5);
+        assertTrue(percentages[3]==25.0);
+    }
+
+    @Test
+    public void testNaturalBreaksHistogramWithPercentages() throws Exception {
+        RenderedImage image = createImage();
+
+        ParameterBlockJAI pb = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb.addSource(image);
+        pb.setParameter("method", ClassificationMethod.NATURAL_BREAKS);
+        pb.setParameter("numClasses", 4);
+        pb.setParameter("extrema", getExtrema(image));
+        pb.setParameter("histogram", true);
+        pb.setParameter("histogramBins", 100);
+        pb.setParameter("percentages",true);
+        RenderedImage op  = JAI.create("ClassBreaks", pb, null);
+        Classification classification =
+                (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification);
+        double[] percentages = classification.getPercentages();
+        assertEquals(4, percentages.length);
+        assertTrue(percentages[0]==18.75);
+        assertTrue(percentages[1]==43.75);
+        assertTrue(percentages[2]==12.5);
+        assertTrue(percentages[3]==25.0);
+    }
+
+    @Test
+    public void testQuantileBreaksWithPercentages() throws Exception {
+        RenderedImage image = createImage();
+
+        ParameterBlockJAI pb = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb.addSource(image);
+        pb.setParameter("method", ClassificationMethod.QUANTILE);
+        pb.setParameter("numClasses", 4);
+        pb.setParameter("percentages",true);
+        RenderedImage op  = JAI.create("ClassBreaks", pb, null);
+        Classification classification =
+                (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification);
+        double[] percentages = classification.getPercentages();
+        assertEquals(percentages.length, 4);
+        assertTrue(percentages[0]== 18.75);
+        assertTrue(percentages[1]== 31.25);
+        assertTrue(percentages[2]== 25.0);
+        assertTrue(percentages[3]== 25.0);
+    }
+
+    @Test
+    public void testQuantileBreaksPercentagesMoreClassesThaIntervals(){
+        RenderedImage image = ImageUtilities.createImageFromArray(
+                new Number[] {1,1,1,1,1,1,1,1,8,8,8,8,3,3,3,3}, 4, 4);
+        ParameterBlockJAI pb = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb.addSource(image);
+        pb.setParameter("method", ClassificationMethod.QUANTILE);
+        pb.setParameter("numClasses", 5);
+        pb.setParameter("percentages",true);
+        RenderedImage op  = JAI.create("ClassBreaks", pb, null);
+        Classification classification =
+                (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification);
+        double[] percentages = classification.getPercentages();
+        assertEquals(percentages.length, 2);
+        assertTrue(percentages[0]==50.0);
+        assertTrue(percentages[1]==50.0);
+    }
+
+    @Test
+    public void testQuantileBreaksHistogramWithPercentages() throws Exception {
+        RenderedImage image = createImage();
+        ParameterBlockJAI pb = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb.addSource(image);
+        pb.setParameter("method", ClassificationMethod.QUANTILE);
+        pb.setParameter("numClasses", 4);
+        pb.setParameter("extrema", getExtrema(image));
+        pb.setParameter("histogram", true);
+        pb.setParameter("histogramBins", 100);
+        pb.setParameter("percentages",true);
+        RenderedImage op  = JAI.create("ClassBreaks", pb, null);
+        Classification classification =
+                (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification);
+        double[] percentages = classification.getPercentages();
+        assertEquals(percentages.length, 4);
+        assertTrue(percentages[0]== 31.25);
+        assertTrue(percentages[1]== 18.75);
+        assertTrue(percentages[2]== 25.0);
+        assertTrue(percentages[3]== 25.0);
+    }
+
+    @Test
+    public void testQuantileBreaksHistogramsPercentagesMoreClassesThaIntervals(){
+        RenderedImage image2 = ImageUtilities.createImageFromArray(
+                new Number[] {1,1,1,1,1,1,1,1,8,8,8,8,11,11,11,16}, 4, 4);
+        ParameterBlockJAI pb2 = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb2.addSource(image2);
+        pb2.setParameter("method", ClassificationMethod.QUANTILE);
+        pb2.setParameter("numClasses", 5);
+        pb2.setParameter("extrema", getExtrema(image2));
+        pb2.setParameter("histogram", true);
+        pb2.setParameter("histogramBins", 100);
+        pb2.setParameter("percentages",true);
+        RenderedImage op2  = JAI.create("ClassBreaks", pb2, null);
+        Classification classification2 =
+                (Classification) op2.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification2);
+        double[] percentages2 = classification2.getPercentages();
+        assertEquals(percentages2.length, 3);
+        assertTrue(percentages2[0]==50.0);
+        assertTrue(percentages2[1]==25.0);
+        assertTrue(percentages2[2]==25.0);
+    }
+
+    @Test
+    public void testEqualIntervalBreaksWithPercentages() throws Exception {
+        RenderedImage image = createImage();
+
+        ParameterBlockJAI pb = new ParameterBlockJAI(new ClassBreaksDescriptor());
+        pb.addSource(image);
+        pb.setParameter("method", ClassificationMethod.EQUAL_INTERVAL);
+        pb.setParameter("numClasses", 4);
+        pb.setParameter("percentages",true);
+        RenderedImage op  = JAI.create("ClassBreaks", pb, null);
+        Classification classification =
+                (Classification) op.getProperty(ClassBreaksDescriptor.CLASSIFICATION_PROPERTY);
+        assertNotNull(classification);
+        double[] percentages = classification.getPercentages();
+        assertEquals(percentages.length, 4);
+        assertTrue(percentages[0]== 56.25);
+        assertTrue(percentages[1]== 31.25);
+        assertTrue(percentages[2]== 0.0);
+        assertTrue(percentages[3]== 12.5);
     }
 
     private Double[][] getExtrema(RenderedImage image) {


### PR DESCRIPTION
Issue https://github.com/geosolutions-it/jai-ext/issues/260

Percentages to the [EqualAreaBreaksOpImage ](https://github.com/taba90/jai-ext/blob/4482ff2b4a1c9b3dc1b7bddf31079f4b088b88a3/jt-classbreaks/src/main/java/it/geosolutions/jaiext/classbreaks/EqualIntervalBreaksOpImage.java)class
have not been added due to the fact that geoserver compute equal intervals inside sld module