### PR TITLE
Avoid repeated reads from the source image

### DIFF
--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/RepeatedReadOptimizer.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/RepeatedReadOptimizer.java
@@ -1,0 +1,114 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2018 GeoSolutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.geosolutions.jaiext.jiffle.parser;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import it.geosolutions.jaiext.jiffle.parser.node.Expression;
+import it.geosolutions.jaiext.jiffle.parser.node.FunctionCall;
+import it.geosolutions.jaiext.jiffle.parser.node.GetSourceValue;
+import it.geosolutions.jaiext.jiffle.parser.node.ImagePos;
+import it.geosolutions.jaiext.jiffle.parser.node.ScalarLiteral;
+import it.geosolutions.jaiext.jiffle.parser.node.SourceWriter;
+
+/**
+ * Support class that helps avoiding repeated reads on the source images, for the common case where
+ * the source image reference is the current pixel (no offsets, no absolute references).
+ */
+public class RepeatedReadOptimizer {
+
+    /**
+     * The compiler generates multiple GetSourceValue for the same kind of read, in case it's a
+     * repeated one (same source reference in multiple parts of the script). Trying to reduce them
+     * all to one causes compile failures, so left them as is, and hid the ugly part in this class.
+     */
+    Map<GetSourceValue, List<GetSourceValue>> sourceValues = new LinkedHashMap<>();
+
+    /**
+     * Adds a source value reference
+     *
+     * @param node
+     */
+    public void add(GetSourceValue node) {
+        List<GetSourceValue> sourceValues =
+                this.sourceValues.computeIfAbsent(node, f -> new ArrayList<>());
+        sourceValues.add(node);
+    }
+
+    /**
+     * Declares a local variable for each read that is repeated at least once, creating local
+     * variables, and making the {@link GetSourceValue} instances emit the new local variable
+     * reference. Please call {@link #resetVariables()} to allow re-using the script one more time.
+     */
+    public void declareRepeatedReads(SourceWriter w) {
+        for (GetSourceValue sourceValue : sourceValues.keySet()) {
+            List<GetSourceValue> valuesList = sourceValues.get(sourceValue);
+            if (valuesList.size() > 1) {
+                ImagePos pos = sourceValue.getPos();
+                Expression band = pos.getBand().getIndex();
+                Expression x = pos.getPixel().getX();
+                Expression y = pos.getPixel().getY();
+                SourceWriter varWriter = new SourceWriter(w.getRuntimeModel());
+                if (band instanceof ScalarLiteral && isPosition(x) && isPosition(y)) {
+                    // prefixes are used to separate variables "sv_" stands for source value
+                    varWriter.append("sv_").append(sourceValue.getVarName()).append("_");
+                    x.write(varWriter);
+                    varWriter.append("_");
+                    y.write(varWriter);
+                    varWriter.append("_");
+                    band.write(varWriter);
+                    String variableName = varWriter.getSource().replace("-", "_");
+
+                    w.indent();
+                    w.append("double ").append(variableName).append(" = ");
+                    sourceValue.write(w);
+                    w.append(";");
+                    w.newLine();
+
+                    for (GetSourceValue reference : valuesList) {
+                        reference.setVariableName(variableName);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks that the expression is just a proxy to a variable (e.g., <code>_x</code> or <code>_y
+     * </code>) or an absolute reference to a fixed pixel.
+     */
+    private boolean isPosition(Expression x) {
+        return (x instanceof FunctionCall && ((FunctionCall) x).isProxy())
+                || x instanceof ScalarLiteral;
+    }
+
+    /** Resets the local variables references. */
+    public void resetVariables() {
+        for (GetSourceValue sourceValue : sourceValues.keySet()) {
+            List<GetSourceValue> valuesList = sourceValues.get(sourceValue);
+            if (valuesList.size() > 1) {
+                for (GetSourceValue reference : valuesList) {
+                    reference.setVariableName(null);
+                }
+            }
+        }
+    }
+}

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/RuntimeModelWorker.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/RuntimeModelWorker.java
@@ -161,7 +161,8 @@ public class RuntimeModelWorker extends AbstractModelWorker {
         Set<String> sourceImages = globalScope.getByType(Symbol.Type.SOURCE_IMAGE);
         Set<String> destImages = globalScope.getByType(Symbol.Type.DEST_IMAGE);
 
-        this.script = new Script(options, sourceImages, destImages, globals, stmts);
+        this.script = new Script(options, sourceImages, destImages, globals, stmts,
+                readsOptimizer);
         set(ctx, this.script);
     }
 

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/GetSourceValue.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/GetSourceValue.java
@@ -56,6 +56,7 @@ public class GetSourceValue extends Expression {
     
     private final String varName;
     private final ImagePos pos;
+    private String variableName;
 
     public GetSourceValue(String varName, ImagePos pos) {
         super(JiffleType.D);
@@ -74,7 +75,9 @@ public class GetSourceValue extends Expression {
     }
 
     public void write(SourceWriter w) {
-        if (w.isInternalBaseClass()) {
+        if (variableName != null) {
+            w.append(variableName);
+        } else if (w.isInternalBaseClass()) {
             w.append("s_").append(varName).append(".read(").append(pos).append(")");
         } else {
             w.append("readFromImage(\"").append(varName).append("\", ").append(pos).append(")");                
@@ -111,5 +114,9 @@ public class GetSourceValue extends Expression {
      */
     public ImagePos getPos() {
         return pos;
+    }
+
+    public void setVariableName(String variableName) {
+        this.variableName = variableName;
     }
 }

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/Script.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/Script.java
@@ -48,9 +48,11 @@ import static java.lang.String.format;
 import it.geosolutions.jaiext.jiffle.Jiffle;
 import it.geosolutions.jaiext.jiffle.parser.JiffleParserException;
 import it.geosolutions.jaiext.jiffle.parser.OptionLookup;
+import it.geosolutions.jaiext.jiffle.parser.RepeatedReadOptimizer;
 import it.geosolutions.jaiext.jiffle.parser.UndefinedOptionException;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -58,6 +60,7 @@ import java.util.Set;
 /** @author michael */
 public class Script implements Node {
     private final StatementList stmts;
+    private final RepeatedReadOptimizer readOptimizer;
     private Map<String, String> options;
     private Set<String> sourceImages;
     private Set<String> destImages;
@@ -68,12 +71,14 @@ public class Script implements Node {
             Set<String> sourceImages,
             Set<String> destImages,
             GlobalVars globals,
-            StatementList stmts) {
+            StatementList stmts,
+            RepeatedReadOptimizer readOptimizer) {
         this.options = options;
         this.sourceImages = sourceImages;
         this.destImages = destImages;
         this.globals = globals;
         this.stmts = stmts;
+        this.readOptimizer = readOptimizer;
     }
 
     public void write(SourceWriter w) {
@@ -210,6 +215,9 @@ public class Script implements Node {
         w.dec();
         w.line("}");
         w.line("_stk.clear();");
+
+        // centralize the source reads to avoid repeated reads
+        readOptimizer.declareRepeatedReads(w);
 
         // the actual script
         w.newLine();

--- a/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/runtime/RuntimeTestBase.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/runtime/RuntimeTestBase.java
@@ -148,6 +148,7 @@ public abstract class RuntimeTestBase {
         testDirectRuntime(srcImg, directRuntimeInstance, evaluator);
         
         // and now the indirect one
+        jiffle = new Jiffle(script, imageParams);
         indirectRuntimeInstance =
                 (JiffleIndirectRuntime) jiffle.getRuntimeInstance(Jiffle.RuntimeModel.INDIRECT);
         evaluator.reset();

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/life-edges-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/life-edges-DIRECT.java
@@ -30,6 +30,7 @@ _outsideValue = 0;
             initImageScopeVars();
         }
         _stk.clear();
+        double sv_world__x__y_0 = s_world.read(_x, _y, 0);
 
         double v_n = 0.0;
         final int _loiy = (int) (-1);
@@ -41,7 +42,7 @@ _outsideValue = 0;
                 v_n += s_world.read(_x + v_ix, _y + v_iy, 0);
             }
         }
-        v_n -= s_world.read(_x, _y, 0);
-        d_nextworld.write(_x, _y, 0, _FN.OR((_FN.EQ(v_n, 3)), (_FN.AND(s_world.read(_x, _y, 0), _FN.EQ(v_n, 2)))));
+        v_n -= sv_world__x__y_0;
+        d_nextworld.write(_x, _y, 0, _FN.OR((_FN.EQ(v_n, 3)), (_FN.AND(sv_world__x__y_0, _FN.EQ(v_n, 2)))));
     }
 }

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/life-toroid-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/life-toroid-DIRECT.java
@@ -26,6 +26,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        double sv_world__x__y_0 = s_world.read(_x, _y, 0);
 
         double v_n = 0.0;
         final int _loiy = (int) (-1);
@@ -43,7 +44,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
                 v_n += s_world.read(v_xx, v_yy, 0);
             }
         }
-        v_n -= s_world.read(_x, _y, 0);
-        d_nextworld.write(_x, _y, 0, _FN.OR((_FN.EQ(v_n, 3)), (_FN.AND(s_world.read(_x, _y, 0), _FN.EQ(v_n, 2)))));
+        v_n -= sv_world__x__y_0;
+        d_nextworld.write(_x, _y, 0, _FN.OR((_FN.EQ(v_n, 3)), (_FN.AND(sv_world__x__y_0, _FN.EQ(v_n, 2)))));
     }
 }

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/ndvi-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/ndvi-DIRECT.java
@@ -28,7 +28,9 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        double sv_nir__x__y_0 = s_nir.read(_x, _y, 0);
+        double sv_red__x__y_0 = s_red.read(_x, _y, 0);
 
-        d_res.write(_x, _y, 0, (s_nir.read(_x, _y, 0) - s_red.read(_x, _y, 0)) / (s_nir.read(_x, _y, 0) + s_red.read(_x, _y, 0)));
+        d_res.write(_x, _y, 0, (sv_nir__x__y_0 - sv_red__x__y_0) / (sv_nir__x__y_0 + sv_red__x__y_0));
     }
 }

--- a/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleOpImage.java
+++ b/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleOpImage.java
@@ -46,6 +46,7 @@ import java.awt.*;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Vector;
@@ -139,6 +140,9 @@ public class JiffleOpImage extends OpImage {
         double[] pixel = new double[destBands];
         for (int y = destRect.y, iy = 0; iy < destRect.height; y++, iy++) {
             for (int x = destRect.x, ix = 0; ix < destRect.width; x++, ix++) {
+                // the script might not be always setting the output value, it may be conditional,
+                // the default value should be Double.NaN
+                Arrays.fill(pixel, Double.NaN);
                 runtime.evaluate(x, y, pixel);
                 dest.setPixel(x, y, pixel);
             }


### PR DESCRIPTION
This is done by storing the values in local variables at the beginning
of the Java translated method, no need for extra data structures, lookups and potential multithreaded script usage issues.