### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <guava.version>27.0-jre</guava.version>
     <jts.version>1.17.0</jts.version>
     <project.version>1.1-SNAPSHOT</project.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <!-- ======================================================== -->
@@ -566,6 +567,11 @@
           </includes>
           <forkMode>once</forkMode>
           <argLine>-Xmx${test.maxHeapSize} -XX:MaxPermSize=${test.maxPermSize} -enableassertions -Dtest.extensive=${extensive.tests} -Dtest.interactive=${interactive.tests}</argLine>
+        	<parallel>classes</parallel>
+        	<useUnlimitedThreads>true</useUnlimitedThreads>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
+
+
          </configuration>
       </plugin>
 	  


### PR DESCRIPTION

According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
