### PR TITLE
Adding minx/max operations to algebra operator. Ignore nodata values

### DIFF
--- a/jt-algebra/src/main/java/it/geosolutions/jaiext/algebra/AlgebraDescriptor.java
+++ b/jt-algebra/src/main/java/it/geosolutions/jaiext/algebra/AlgebraDescriptor.java
@@ -22,6 +22,7 @@ import it.geosolutions.jaiext.range.Range;
 import java.awt.RenderingHints;
 import java.awt.image.DataBuffer;
 import java.awt.image.RenderedImage;
+import java.awt.image.renderable.ParameterBlock;
 import java.awt.image.renderable.RenderableImage;
 
 import javax.media.jai.JAI;
@@ -1169,7 +1170,162 @@ public class AlgebraDescriptor extends OperationDescriptorImpl {
                 }
                 return result;
             }
-        };
+        },MAX(14, Integer.MIN_VALUE, true) {
+            @Override
+            public byte calculate(byte... values) {
+                byte result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    byte value = values[i];
+                    if (value > result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public short calculate(short... values) {
+                short result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    short value = values[i];
+                    if (value > result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public short calculate(boolean isUshort, short... values) {
+                if (isUshort) {
+                    int result = values[0] & ImageUtil.USHORT_MASK;
+                    for (int i = 1; i < values.length; i++) {
+                        int value = values[i] & ImageUtil.USHORT_MASK;
+                        if (value > result) result = value;
+                    }
+                    return (short) result;                    
+                } else {
+                    // call the "short" specific method instead
+                    return calculate(values);
+                }
+            }
+
+            @Override
+            public int calculate(int... values) {
+                int result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    int value = values[i];
+                    if (value > result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public float calculate(float... values) {
+                float result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    float value = values[i];
+                    if (value > result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public double calculate(double... values) {
+                double result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    double value = values[i];
+                    if (value > result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public long calculateL(long... values) {
+                long result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    long value = values[i];
+                    if (value > result) result = value;
+                }
+                return result;
+            }
+        },
+        MIN(15, Integer.MAX_VALUE, true) {
+            @Override
+            public byte calculate(byte... values) {
+                byte result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    byte value = values[i];
+                    if (value < result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public short calculate(short... values) {
+                short result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    short value = values[i];
+                    if (value < result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public short calculate(boolean isUshort, short... values) {
+                if (isUshort) {
+                    int result = values[0] & ImageUtil.USHORT_MASK;
+                    for (int i = 1; i < values.length; i++) {
+                        int value = values[i] & ImageUtil.USHORT_MASK;
+                        if (value < result) result = value;
+                    }
+                    return (short) result;
+                } else {
+                    // call the "short" specific method instead
+                    return calculate(values);
+                }
+            }
+
+            @Override
+            public int calculate(int... values) {
+                int result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    int value = values[i];
+                    if (value < result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public float calculate(float... values) {
+                float result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    float value = values[i];
+                    if (value < result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public double calculate(double... values) {
+                double result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    double value = values[i];
+                    if (value < result) result = value;
+                }
+                return result;
+            }
+
+            @Override
+            public long calculateL(long... values) {
+                long result = values[0];
+                for (int i = 1; i < values.length; i++) {
+                    long value = values[i];
+                    if (value < result) result = value;
+                }
+                return result;
+            }
+        }
+
+        ;
+        
+        
 
         private final double nullValue;
 
@@ -1307,7 +1463,7 @@ public class AlgebraDescriptor extends OperationDescriptorImpl {
      * 
      * <p>
      * Creates a <code>ParameterBlockJAI</code> from all supplied arguments except <code>hints</code> and invokes
-     * {@link JAI#create(String,ParameterBlock,RenderingHints)}.
+     * {@link JAI#create(String, ParameterBlock,RenderingHints)}.
      * 
      * @see JAI
      * @see ParameterBlockJAI

--- a/jt-algebra/src/main/java/it/geosolutions/jaiext/algebra/AlgebraOpImage.java
+++ b/jt-algebra/src/main/java/it/geosolutions/jaiext/algebra/AlgebraOpImage.java
@@ -40,28 +40,32 @@ import com.sun.media.jai.util.ImageUtil;
 import com.sun.media.jai.util.JDKWorkarounds;
 
 /**
- * An <code>OpImage</code> implementing any operation defined by the {@link Operator} enum on an image array.
- * 
+ * An <code>OpImage</code> implementing any operation defined by the {@link Operator} enum on an 
+ * image array.
+ *
  * <p>
- * This <code>OpImage</code> executes the operation on the pixel values of N source images on a per-band basis. In case the N source images have different number of
- * bands, the number of bands for the destination image is the smaller band number of the N source images. That is
- * <code>dstNumBands = Math.min(src1NumBands, src2NumBands,...)</code>. In case the source images have different data types, the data type
+ * This <code>OpImage</code> executes the operation on the pixel values of N source images on a 
+ * per-band basis. In case the N source images have different number of
+ * bands, the number of bands for the destination image is the smaller band number of the N 
+ * source images. That is
+ * <code>dstNumBands = Math.min(src1NumBands, src2NumBands,...)</code>. In case the source images
+ * have different data types, the data type
  * for the destination image is the bigger data type of the two source images.
- * 
+ *
  * <p>
  * The value of the pixel (x, y) in the destination image is defined as:
- * 
+ *
  * <pre>
  * for (b = 0; b &lt; numBands; b++) {
  *     dst[y][x][b] = op.calculate(src1[y][x][b],src2[y][x][b]);
  * }
  * </pre>
- * 
+ *
  * <p>
- * If the result of the operation overflows/underflows the maximum/minimum value supported by the destination image, then it will be clamped to the
- * maximum/minimum value respectively. The data type <code>byte</code> is treated as unsigned, with maximum value as 255 and minimum value as 0.
- * 
- * 
+ * If the result of the operation overflows/underflows the maximum/minimum value supported by the
+ * destination image, then it will be clamped to the
+ * maximum/minimum value respectively. The data type <code>byte</code> is treated as unsigned, 
+ * with maximum value as 255 and minimum value as 0.
  */
 public class AlgebraOpImage extends PointOpImage {
 
@@ -113,25 +117,28 @@ public class AlgebraOpImage extends PointOpImage {
 
     /**
      * Constructs an <code>AlgebraOpImage</code>.
-     * 
+     *
      * <p>
-     * The <code>layout</code> parameter may optionally contains the tile grid layout, sample model, and/or color model. The image dimension is
+     * The <code>layout</code> parameter may optionally contains the tile grid layout, sample 
+     * model, and/or color model. The image dimension is
      * determined by the intersection of the bounding boxes of the two source images.
-     * 
+     *
      * <p>
-     * The image layout of the first source image, <code>source1</code>, is used as the fall-back for the image layout of the destination image. Any
-     * layout parameters not specified in the <code>layout</code> argument are set to the same value as that of <code>source1</code>.
-     * 
-     * @param config the hints
-     * @param layout The destination image layout.
-     * @param op Operation selected
-     * @param srcROI ROI used for reducing computation Area
-     * @param noData NoData Range used for checking noData
+     * The image layout of the first source image, <code>source1</code>, is used as the fall-back
+     * for the image layout of the destination image. Any
+     * layout parameters not specified in the <code>layout</code> argument are set to the same 
+     * value as that of <code>source1</code>.
+     *
+     * @param config            the hints
+     * @param layout            The destination image layout.
+     * @param op                Operation selected
+     * @param srcROI            ROI used for reducing computation Area
+     * @param noData            NoData Range used for checking noData
      * @param destinationNoData value for replacing the source nodata values
-     * @param sources Array of Sources
+     * @param sources           Array of Sources
      */
     public AlgebraOpImage(Map config, ImageLayout layout, Operator op, ROI srcROI, Range noData,
-            double destinationNoData, RenderedImage... sources) {
+                          double destinationNoData, RenderedImage... sources) {
         super(vectorize(sources), layout, config, true);
 
         if (op == null) {
@@ -148,7 +155,7 @@ public class AlgebraOpImage extends PointOpImage {
             LOGGER.warning("Multiple sources found, only the first one will be used");
             numSrc = 1;
         }
-        
+
         this.numSrc = numSrc;
         this.numTotalSrc = sources.length;
 
@@ -162,9 +169,9 @@ public class AlgebraOpImage extends PointOpImage {
 //                throw new IllegalArgumentException("Images must have the same data type");
 //            }
 //        }
-        
+
         // DataType check for the operation
-        if(!op.isDataTypeSupported(srcDataType)){
+        if (!op.isDataTypeSupported(srcDataType)) {
             throw new IllegalArgumentException("This operation does not support DataType: " + srcDataType);
         }
 
@@ -225,32 +232,32 @@ public class AlgebraOpImage extends PointOpImage {
 
         // Destination No Data value is clamped to the image data type
         switch (dataType) {
-        case DataBuffer.TYPE_BYTE:
-            this.destNoDataByte = ImageUtil.clampRoundByte(destinationNoData);
-            this.nullValueByte = ImageUtil.clampRoundByte(op.getNullValue());
-            break;
-        case DataBuffer.TYPE_USHORT:
-            this.destNoDataShort = ImageUtil.clampRoundUShort(destinationNoData);
-            this.nullValueShort = ImageUtil.clampRoundUShort(op.getNullValue());
-            break;
-        case DataBuffer.TYPE_SHORT:
-            this.destNoDataShort = ImageUtil.clampRoundShort(destinationNoData);
-            this.nullValueShort = ImageUtil.clampRoundShort(op.getNullValue());
-            break;
-        case DataBuffer.TYPE_INT:
-            this.destNoDataInt = ImageUtil.clampRoundInt(destinationNoData);
-            this.nullValueInt = ImageUtil.clampRoundInt(op.getNullValue());
-            break;
-        case DataBuffer.TYPE_FLOAT:
-            this.destNoDataFloat = ImageUtil.clampFloat(destinationNoData);
-            this.nullValueFloat = ImageUtil.clampFloat(op.getNullValue());
-            break;
-        case DataBuffer.TYPE_DOUBLE:
-            this.destNoDataDouble = destinationNoData;
-            this.nullValueDouble = op.getNullValue();
-            break;
-        default:
-            throw new IllegalArgumentException("Wrong image data type");
+            case DataBuffer.TYPE_BYTE:
+                this.destNoDataByte = ImageUtil.clampRoundByte(destinationNoData);
+                this.nullValueByte = ImageUtil.clampRoundByte(op.getNullValue());
+                break;
+            case DataBuffer.TYPE_USHORT:
+                this.destNoDataShort = ImageUtil.clampRoundUShort(destinationNoData);
+                this.nullValueShort = ImageUtil.clampRoundUShort(op.getNullValue());
+                break;
+            case DataBuffer.TYPE_SHORT:
+                this.destNoDataShort = ImageUtil.clampRoundShort(destinationNoData);
+                this.nullValueShort = ImageUtil.clampRoundShort(op.getNullValue());
+                break;
+            case DataBuffer.TYPE_INT:
+                this.destNoDataInt = ImageUtil.clampRoundInt(destinationNoData);
+                this.nullValueInt = ImageUtil.clampRoundInt(op.getNullValue());
+                break;
+            case DataBuffer.TYPE_FLOAT:
+                this.destNoDataFloat = ImageUtil.clampFloat(destinationNoData);
+                this.nullValueFloat = ImageUtil.clampFloat(op.getNullValue());
+                break;
+            case DataBuffer.TYPE_DOUBLE:
+                this.destNoDataDouble = destinationNoData;
+                this.nullValueDouble = op.getNullValue();
+                break;
+            default:
+                throw new IllegalArgumentException("Wrong image data type");
         }
 
         // Check if No Data control must be done
@@ -264,12 +271,11 @@ public class AlgebraOpImage extends PointOpImage {
                 byteLookupTable = new byte[256];
 
                 for (int i = 0; i < byteLookupTable.length; i++) {
-                    byte value = (byte) i;
 
-                    booleanLookupTable[i] = !noData.contains(value);
+                    booleanLookupTable[i] = !noData.contains(i);
 
                     if (booleanLookupTable[i]) {
-                        byteLookupTable[i] = value;
+                        byteLookupTable[i] = (byte) i;
                     } else {
                         byteLookupTable[i] = nullValueByte;
                     }
@@ -305,9 +311,10 @@ public class AlgebraOpImage extends PointOpImage {
 
     /**
      * Computes the final pixel from N source images within a specified rectangle.
-     * 
-     * @param sources Cobbled sources, guaranteed to provide all the source data necessary for computing the rectangle.
-     * @param dest The tile containing the rectangle to be computed.
+     *
+     * @param sources  Cobbled sources, guaranteed to provide all the source data necessary for 
+     *                 computing the rectangle.
+     * @param dest     The tile containing the rectangle to be computed.
      * @param destRect The rectangle within the tile to be computed.
      */
     protected void computeRect(Raster[] sources, WritableRaster dest, Rectangle destRect) {
@@ -327,24 +334,24 @@ public class AlgebraOpImage extends PointOpImage {
                     getColorModel());
 
             switch (d.getDataType()) {
-            case DataBuffer.TYPE_BYTE:
-                computeRectByte(rasterArray, d);
-                break;
-            case DataBuffer.TYPE_USHORT:
-                computeRectUShort(rasterArray, d);
-                break;
-            case DataBuffer.TYPE_SHORT:
-                computeRectShort(rasterArray, d);
-                break;
-            case DataBuffer.TYPE_INT:
-                computeRectInt(rasterArray, d);
-                break;
-            case DataBuffer.TYPE_FLOAT:
-                computeRectFloat(rasterArray, d);
-                break;
-            case DataBuffer.TYPE_DOUBLE:
-                computeRectDouble(rasterArray, d);
-                break;
+                case DataBuffer.TYPE_BYTE:
+                    computeRectByte(rasterArray, d);
+                    break;
+                case DataBuffer.TYPE_USHORT:
+                    computeRectUShort(rasterArray, d);
+                    break;
+                case DataBuffer.TYPE_SHORT:
+                    computeRectShort(rasterArray, d);
+                    break;
+                case DataBuffer.TYPE_INT:
+                    computeRectInt(rasterArray, d);
+                    break;
+                case DataBuffer.TYPE_FLOAT:
+                    computeRectFloat(rasterArray, d);
+                    break;
+                case DataBuffer.TYPE_DOUBLE:
+                    computeRectDouble(rasterArray, d);
+                    break;
             }
 
             if (d.needsClamping()) {
@@ -357,22 +364,22 @@ public class AlgebraOpImage extends PointOpImage {
             double[] destNoData = new double[numBands];
             for (int i = 0; i < numBands; i++) {
                 switch (destDataType) {
-                case DataBuffer.TYPE_BYTE:
-                    destNoData[i] = destNoDataByte;
-                    break;
-                case DataBuffer.TYPE_USHORT:
-                case DataBuffer.TYPE_SHORT:
-                    destNoData[i] = destNoDataShort;
-                    break;
-                case DataBuffer.TYPE_INT:
-                    destNoData[i] = destNoDataInt;
-                    break;
-                case DataBuffer.TYPE_FLOAT:
-                    destNoData[i] = destNoDataFloat;
-                    break;
-                case DataBuffer.TYPE_DOUBLE:
-                    destNoData[i] = destNoDataDouble;
-                    break;
+                    case DataBuffer.TYPE_BYTE:
+                        destNoData[i] = destNoDataByte;
+                        break;
+                    case DataBuffer.TYPE_USHORT:
+                    case DataBuffer.TYPE_SHORT:
+                        destNoData[i] = destNoDataShort;
+                        break;
+                    case DataBuffer.TYPE_INT:
+                        destNoData[i] = destNoDataInt;
+                        break;
+                    case DataBuffer.TYPE_FLOAT:
+                        destNoData[i] = destNoDataFloat;
+                        break;
+                    case DataBuffer.TYPE_DOUBLE:
+                        destNoData[i] = destNoDataDouble;
+                        break;
                 }
             }
             ImageUtil.fillBackground(dest, destRect, destNoData);
@@ -536,26 +543,22 @@ public class AlgebraOpImage extends PointOpImage {
                     dLineOffset += dLineStride;
 
                     for (int w = 0; w < dwidth; w++) {
-
                         isValidData = false;
 
                         sourceValue = srcData[0][srcPixelOffset[0]] & 0xFF;
-
-                        result = byteLookupTable[sourceValue] & 0xFF;
                         isValidData |= booleanLookupTable[sourceValue];
                         if (isValidData) {
-                            result = op.calculate(srcData[0][srcPixelOffset[0]]) & 0xFF;
+                            result = op.calculate(sourceValue) & 0xFF;
                         }
                         srcPixelOffset[0] += srcPixelStride[0];
 
                         for (int i = 1; i < numSrc; i++) {
                             sourceValue = srcData[i][srcPixelOffset[i]] & 0xFF;
 
-                            isValidData |= booleanLookupTable[sourceValue];
-
+                            boolean validPixel = booleanLookupTable[sourceValue];
                             inputData = byteLookupTable[sourceValue] & 0xFF;
-
-                            result = op.calculate(result, inputData);
+                            result = updateResultInteger(validPixel, inputData, isValidData, result);
+                            isValidData |= validPixel;
 
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
@@ -617,23 +620,20 @@ public class AlgebraOpImage extends PointOpImage {
                         }
 
                         sourceValue = srcData[0][srcPixelOffset[0]] & 0xFF;
-
-                        result = byteLookupTable[sourceValue] & 0xFF;
                         isValidData |= booleanLookupTable[sourceValue];
                         if (isValidData) {
-                            result = op.calculate(srcData[0][srcPixelOffset[0]]) & 0xFF;
+                            result = op.calculate(sourceValue) & 0xFF;
                         }
                         srcPixelOffset[0] += srcPixelStride[0];
 
                         for (int i = 1; i < numSrc; i++) {
                             sourceValue = srcData[i][srcPixelOffset[i]] & 0xFF;
 
-                            isValidData |= booleanLookupTable[sourceValue];
-
+                            boolean validPixel = booleanLookupTable[sourceValue];
                             inputData = byteLookupTable[sourceValue] & 0xFF;
 
-                            result = op.calculate(result, inputData);
-
+                            result = updateResultInteger(validPixel, inputData, isValidData, result);
+                            isValidData |= validPixel;
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -659,6 +659,73 @@ public class AlgebraOpImage extends PointOpImage {
         }
     }
 
+    /**
+     * Applies the operation on the current pixel value and result, considering the following cases:
+     * <ul>
+     *     <li>If the pixel is not valid, skip</li>
+     *     <li>If the pixel is valid and it's the first, initialize result</li>
+     *     <li>Otherwise normal computation</li>
+     * </ul>
+     *
+     * @param validValue Whether or not the pixel is valid
+     * @param value The pixel value
+     * @param validResult Whether the current result is valid
+     * @param result The current result value
+     * @return
+     */
+    private int updateResultInteger(boolean validValue, int value, boolean validResult, int result) {
+        if (validValue) {
+            if (!validResult) {
+                result = op.calculate(value) & 0xFF;
+            } else {
+                result = op.calculate(result, value);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #updateResultInteger(boolean, int, boolean, int)} but for long arguments
+     */
+    private long updateResultLong(boolean validValue, long value, boolean validResult, long result) {
+        if (validValue) {
+            if (!validResult) {
+                result = op.calculateL(value);
+            } else {
+                result = op.calculateL(result, value);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #updateResultInteger(boolean, int, boolean, int)} but for float arguments
+     */
+    private float updateResultFloat(boolean validValue, float value, boolean validResult, float result) {
+        if (validValue) {
+            if (!validResult) {
+                result = op.calculate(value);
+            } else {
+                result = op.calculate(result, value);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #updateResultInteger(boolean, int, boolean, int)} but for double arguments
+     */
+    private double updateResultDouble(boolean validValue, double value, boolean validResult, double result) {
+        if (validValue) {
+            if (!validResult) {
+                result = op.calculate(value);
+            } else {
+                result = op.calculate(result, value);
+            }
+        }
+        return result;
+    }
+
     private void computeRectUShort(RasterAccessor[] rasterArray, RasterAccessor dst) {
 
         int[] srcLineStride = new int[numSrc];
@@ -676,7 +743,6 @@ public class AlgebraOpImage extends PointOpImage {
         }
 
         int result = 0;
-        int inputData = 0;
 
         int dwidth = dst.getWidth();
         int dheight = dst.getHeight();
@@ -726,11 +792,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]] & 0xFFFF;
-                            result = op.calculate(result, inputData);
+                            result = op.calculate(result, srcData[i][srcPixelOffset[i]] & 0xFFFF);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampUShort(result);
 
@@ -776,11 +840,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]] & 0xFFFF;
-                            result = op.calculate(result, inputData);
+                            result = op.calculate(result, srcData[i][srcPixelOffset[i]] & 0xFFFF);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampUShort(result);
 
@@ -817,8 +879,6 @@ public class AlgebraOpImage extends PointOpImage {
                             result = op.calculate(op.isUshortSupported(),
                                     srcData[0][srcPixelOffset[0]]) & 0xFFFF;
                             isValidData = true;
-                        } else {
-                            result = nullValueShort;
                         }
 
                         srcPixelOffset[0] += srcPixelStride[0];
@@ -827,13 +887,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue & 0xFFFF;
+                                result = updateResultInteger(true, sourceValue & 0xFFFF, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueShort;
-                            }
+                            } 
 
-                            result = op.calculate(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -842,7 +899,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampUShort(result);
 
@@ -901,13 +957,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue & 0xFFFF;
+                                result = updateResultInteger(true, sourceValue & 0xFFFF, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueShort;
                             }
 
-                            result = op.calculate(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -916,7 +969,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampUShort(result);
 
@@ -926,6 +978,8 @@ public class AlgebraOpImage extends PointOpImage {
             }
         }
     }
+
+   
 
     private void computeRectShort(RasterAccessor[] rasterArray, RasterAccessor dst) {
 
@@ -944,7 +998,6 @@ public class AlgebraOpImage extends PointOpImage {
         }
 
         int result = 0;
-        short inputData = 0;
 
         int dwidth = dst.getWidth();
         int dheight = dst.getHeight();
@@ -993,11 +1046,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]];
-                            result = op.calculate(result, inputData);
+                            result = op.calculate(result, srcData[i][srcPixelOffset[i]]);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampShort(result);
 
@@ -1042,11 +1093,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]];
-                            result = op.calculate(result, inputData);
+                            result = op.calculate(result, srcData[i][srcPixelOffset[i]]);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampShort(result);
 
@@ -1092,13 +1141,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue;
+                                result = updateResultInteger(true, sourceValue, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueShort;
                             }
 
-                            result = op.calculate(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -1107,7 +1153,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampShort(result);
 
@@ -1165,13 +1210,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue;
+                                result = updateResultInteger(true, sourceValue, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueShort;
-                            }
+                            } 
 
-                            result = op.calculate(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -1180,7 +1222,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampShort(result);
 
@@ -1192,7 +1233,6 @@ public class AlgebraOpImage extends PointOpImage {
     }
 
     private void computeRectInt(RasterAccessor[] rasterArray, RasterAccessor dst) {
-
         int[] srcLineStride = new int[numSrc];
         int[] srcPixelStride = new int[numSrc];
         int[][] srcBandOffsets = new int[numSrc][];
@@ -1208,7 +1248,6 @@ public class AlgebraOpImage extends PointOpImage {
         }
 
         long result = 0;
-        int inputData = 0;
 
         int dwidth = dst.getWidth();
         int dheight = dst.getHeight();
@@ -1257,11 +1296,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]];
-                            result = op.calculateL(result, inputData);
+                            result = op.calculateL(result, srcData[i][srcPixelOffset[i]]);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampInt(result);
 
@@ -1306,11 +1343,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]];
-                            result = op.calculateL(result, inputData);
+                            result = op.calculateL(result, srcData[i][srcPixelOffset[i]]);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampInt(result);
 
@@ -1346,23 +1381,17 @@ public class AlgebraOpImage extends PointOpImage {
                         if (!noData.contains(sourceValue)) {
                             result = op.calculate(sourceValue);
                             isValidData = true;
-                        } else {
-                            result = nullValueInt;
                         }
 
                         srcPixelOffset[0] += srcPixelStride[0];
 
                         for (int i = 1; i < numSrc; i++) {
                             sourceValue = srcData[i][srcPixelOffset[i]];
-
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue;
+                                result = updateResultLong(true, sourceValue, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueInt;
-                            }
+                            } 
 
-                            result = op.calculateL(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -1371,7 +1400,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampInt(result);
 
@@ -1429,13 +1457,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue;
+                                result = updateResultLong(true, sourceValue, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueInt;
-                            }
+                            } 
 
-                            result = op.calculateL(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -1444,7 +1469,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = ImageUtil.clampInt(result);
 
@@ -1472,7 +1496,6 @@ public class AlgebraOpImage extends PointOpImage {
         }
 
         float result = 0;
-        float inputData = 0;
 
         int dwidth = dst.getWidth();
         int dheight = dst.getHeight();
@@ -1521,11 +1544,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]];
-                            result = op.calculate(result, inputData);
+                            result = op.calculate(result, srcData[i][srcPixelOffset[i]]);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = result;
 
@@ -1570,11 +1591,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]];
-                            result = op.calculate(result, inputData);
+                            result = op.calculate(result, srcData[i][srcPixelOffset[i]]);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = result;
 
@@ -1610,8 +1629,6 @@ public class AlgebraOpImage extends PointOpImage {
                         if (!noData.contains(sourceValue)) {
                             result = op.calculate(sourceValue);
                             isValidData = true;
-                        } else {
-                            result = nullValueFloat;
                         }
 
                         srcPixelOffset[0] += srcPixelStride[0];
@@ -1620,13 +1637,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue;
+                                result = updateResultFloat(true, sourceValue, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueFloat;
                             }
 
-                            result = op.calculate(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -1635,7 +1649,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = result;
 
@@ -1679,12 +1692,9 @@ public class AlgebraOpImage extends PointOpImage {
                         }
 
                         sourceValue = srcData[0][srcPixelOffset[0]];
-
                         if (!noData.contains(sourceValue)) {
                             result = op.calculate(sourceValue);
                             isValidData = true;
-                        } else {
-                            result = nullValueFloat;
                         }
 
                         srcPixelOffset[0] += srcPixelStride[0];
@@ -1693,13 +1703,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue;
+                                result = updateResultFloat(true, sourceValue, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueFloat;
-                            }
+                            } 
 
-                            result = op.calculate(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -1708,7 +1715,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = result;
 
@@ -1736,7 +1742,6 @@ public class AlgebraOpImage extends PointOpImage {
         }
 
         double result = 0;
-        double inputData = 0;
 
         int dwidth = dst.getWidth();
         int dheight = dst.getHeight();
@@ -1785,11 +1790,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]];
-                            result = op.calculate(result, inputData);
+                            result = op.calculate(result, srcData[i][srcPixelOffset[i]]);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = result;
 
@@ -1833,11 +1836,9 @@ public class AlgebraOpImage extends PointOpImage {
 
                         srcPixelOffset[0] += srcPixelStride[0];
                         for (int i = 1; i < numSrc; i++) {
-                            inputData = srcData[i][srcPixelOffset[i]];
-                            result = op.calculate(result, inputData);
+                            result = op.calculate(result, srcData[i][srcPixelOffset[i]]);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = result;
 
@@ -1883,13 +1884,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue;
+                                result = updateResultDouble(true, sourceValue, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueDouble;
-                            }
-
-                            result = op.calculate(result, inputData);
+                            } 
+                            
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -1898,7 +1896,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = result;
 
@@ -1956,13 +1953,10 @@ public class AlgebraOpImage extends PointOpImage {
                             sourceValue = srcData[i][srcPixelOffset[i]];
 
                             if (!noData.contains(sourceValue)) {
-                                inputData = sourceValue;
+                                result = updateResultDouble(true, sourceValue, isValidData, result);
                                 isValidData = true;
-                            } else {
-                                inputData = nullValueDouble;
-                            }
+                            } 
 
-                            result = op.calculate(result, inputData);
                             srcPixelOffset[i] += srcPixelStride[i];
                         }
 
@@ -1971,7 +1965,6 @@ public class AlgebraOpImage extends PointOpImage {
                             dPixelOffset += dPixelStride;
                             continue;
                         }
-                        // result = op.calculate(inputData);
 
                         d[dPixelOffset] = result;
 

--- a/jt-algebra/src/test/java/it/geosolutions/jaiext/algebra/AlgebraTest.java
+++ b/jt-algebra/src/test/java/it/geosolutions/jaiext/algebra/AlgebraTest.java
@@ -1,20 +1,20 @@
 /* JAI-Ext - OpenSource Java Advanced Image Extensions Library
-*    http://www.geo-solutions.it/
-*    Copyright 2014 GeoSolutions
+ *    http://www.geo-solutions.it/
+ *    Copyright 2014 GeoSolutions
 
 
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
 
-* http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
 
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package it.geosolutions.jaiext.algebra;
 
 import static org.junit.Assert.assertEquals;
@@ -27,6 +27,7 @@ import java.awt.image.RenderedImage;
 import javax.media.jai.ROI;
 import javax.media.jai.ROIShape;
 import javax.media.jai.RenderedOp;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -81,17 +82,23 @@ public class AlgebraTest extends TestBase {
         IMAGE_FILLER = true;
         for (int j = 0; j < NUM_IMAGES; j++) {
             testImages[DataBuffer.TYPE_BYTE][j] = createTestImage(DataBuffer.TYPE_BYTE,
-                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataB, false, j == 0 ? 1 : 3, 64 + j);
+                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataB, false, j == 0 ? 1 : 3
+                    , 64 + j);
             testImages[DataBuffer.TYPE_USHORT][j] = createTestImage(DataBuffer.TYPE_USHORT,
-                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataS, false, j == 0 ? 1 : 3, Short.MAX_VALUE / 4 + j);
+                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataS, false, j == 0 ? 1 : 3
+                    , Short.MAX_VALUE / 4 + j);
             testImages[DataBuffer.TYPE_SHORT][j] = createTestImage(DataBuffer.TYPE_SHORT,
-                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataS, false, j == 0 ? 1 : 3, -50 + j);
+                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataS, false, j == 0 ? 1 : 3
+                    , -50 + j);
             testImages[DataBuffer.TYPE_INT][j] = createTestImage(DataBuffer.TYPE_INT,
-                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataI, false, j == 0 ? 1 : 3, 100 + j );
+                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataI, false, j == 0 ? 1 : 3
+                    , 100 + j);
             testImages[DataBuffer.TYPE_FLOAT][j] = createTestImage(DataBuffer.TYPE_FLOAT,
-                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataF, false, j == 0 ? 1 : 3, (255 / 2) * 5 + j);
+                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataF, false, j == 0 ? 1 : 3
+                    , (255 / 2) * 5 + j);
             testImages[DataBuffer.TYPE_DOUBLE][j] = createTestImage(DataBuffer.TYPE_DOUBLE,
-                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataD, false, j == 0 ? 1 : 3, (255 / 1) * 4 + j);
+                    DEFAULT_WIDTH_REDUCED, DEFAULT_HEIGHT_REDUCED, noDataD, false, j == 0 ? 1 : 3
+                    , (255 / 1) * 4 + j);
         }
         IMAGE_FILLER = false;
 
@@ -120,8 +127,8 @@ public class AlgebraTest extends TestBase {
 
         boolean roiUsed = false;
         boolean noDataUsed = false;
-        
-        for(int i = 0; i < 6; i++){
+
+        for (int i = 0; i < 6; i++) {
             runTests(i, noDataUsed, roiUsed);
         }
     }
@@ -131,8 +138,8 @@ public class AlgebraTest extends TestBase {
 
         boolean roiUsed = false;
         boolean noDataUsed = true;
-        
-        for(int i = 0; i < 6; i++){
+
+        for (int i = 0; i < 6; i++) {
             runTests(i, noDataUsed, roiUsed);
         }
     }
@@ -142,8 +149,9 @@ public class AlgebraTest extends TestBase {
 
         boolean roiUsed = true;
         boolean noDataUsed = false;
-        
-        for(int i = 0; i < 6; i++){
+
+        for (int i = 0; i < 6; i++) {
+            System.out.println(i);
             runTests(i, noDataUsed, roiUsed);
         }
     }
@@ -153,12 +161,12 @@ public class AlgebraTest extends TestBase {
 
         boolean roiUsed = true;
         boolean noDataUsed = true;
-        
-        for(int i = 0; i < 6; i++){
+
+        for (int i = 0; i < 6; i++) {
             runTests(i, noDataUsed, roiUsed);
         }
     }
-    
+
     private void runTests(int dataType, boolean noDataUsed, boolean roiUsed) {
         testOperation(testImages[dataType], Operator.SUM, noDataUsed, roiUsed);
         testOperation(testImages[dataType], Operator.SUBTRACT, noDataUsed, roiUsed);
@@ -166,7 +174,8 @@ public class AlgebraTest extends TestBase {
         testOperation(testImages[dataType], Operator.DIVIDE, noDataUsed, roiUsed);
         testOperation(testImages[dataType], Operator.LOG, noDataUsed, roiUsed);
         testOperation(testImages[dataType], Operator.EXP, noDataUsed, roiUsed);
-        if(dataType != DataBuffer.TYPE_FLOAT && dataType != DataBuffer.TYPE_DOUBLE){
+        testOperation(testImages[dataType], Operator.MAX, noDataUsed, roiUsed);
+        if (dataType != DataBuffer.TYPE_FLOAT && dataType != DataBuffer.TYPE_DOUBLE) {
             testOperation(testImages[dataType], Operator.ABSOLUTE, noDataUsed, roiUsed);
             testOperation(testImages[dataType], Operator.AND, noDataUsed, roiUsed);
             testOperation(testImages[dataType], Operator.OR, noDataUsed, roiUsed);
@@ -177,7 +186,7 @@ public class AlgebraTest extends TestBase {
     }
 
     private void testOperation(RenderedImage[] sources, Operator op, boolean noDataUsed,
-            boolean roiUsed) {
+                               boolean roiUsed) {
         // Optional No Data Range used
         Range noData;
         // Source image data type
@@ -186,26 +195,26 @@ public class AlgebraTest extends TestBase {
         if (noDataUsed) {
 
             switch (dataType) {
-            case DataBuffer.TYPE_BYTE:
-                noData = noDataByte;
-                break;
-            case DataBuffer.TYPE_USHORT:
-                noData = noDataUShort;
-                break;
-            case DataBuffer.TYPE_SHORT:
-                noData = noDataShort;
-                break;
-            case DataBuffer.TYPE_INT:
-                noData = noDataInt;
-                break;
-            case DataBuffer.TYPE_FLOAT:
-                noData = noDataFloat;
-                break;
-            case DataBuffer.TYPE_DOUBLE:
-                noData = noDataDouble;
-                break;
-            default:
-                throw new IllegalArgumentException("Wrong data type");
+                case DataBuffer.TYPE_BYTE:
+                    noData = noDataByte;
+                    break;
+                case DataBuffer.TYPE_USHORT:
+                    noData = noDataUShort;
+                    break;
+                case DataBuffer.TYPE_SHORT:
+                    noData = noDataShort;
+                    break;
+                case DataBuffer.TYPE_INT:
+                    noData = noDataInt;
+                    break;
+                case DataBuffer.TYPE_FLOAT:
+                    noData = noDataFloat;
+                    break;
+                case DataBuffer.TYPE_DOUBLE:
+                    noData = noDataDouble;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Wrong data type");
             }
         } else {
             noData = null;
@@ -237,39 +246,46 @@ public class AlgebraTest extends TestBase {
         assertEquals(minBandNumber, calculated.getNumBands());
 
         switch (op) {
-        case SUM:
-            testSum(calculated, sources, roi, noData, minBandNumber);
-            break;
-        case SUBTRACT:
-            testSubtract(calculated, sources, roi, noData, minBandNumber);
-            break;
-        case MULTIPLY:
-            testMultiply(calculated, sources, roi, noData, minBandNumber);
-            break;
-        case DIVIDE:
-            testDivide(calculated, sources, roi, noData, minBandNumber);
-            break;
-        case AND:
-        case OR:
-        case XOR:
-            testLogicalOp(calculated, sources, roi, noData, minBandNumber, op);
-            break;
-        case EXP:
-        case NOT:
-        case INVERT:
-        case ABSOLUTE:
-        case LOG:
-            testSingleImageOp(calculated, sources, roi, noData, minBandNumber, op);
-            break;
+            case SUM:
+                testSum(calculated, sources, roi, noData, minBandNumber);
+                break;
+            case SUBTRACT:
+                testSubtract(calculated, sources, roi, noData, minBandNumber);
+                break;
+            case MULTIPLY:
+                testMultiply(calculated, sources, roi, noData, minBandNumber);
+                break;
+            case DIVIDE:
+                testDivide(calculated, sources, roi, noData, minBandNumber);
+                break;
+            case MAX:
+                testMax(calculated, sources, roi, noData, minBandNumber);
+                break;
+            case MIN:
+                testMin(calculated, sources, roi, noData, minBandNumber);
+                break;
+            case AND:
+            case OR:
+            case XOR:
+                testLogicalOp(calculated, sources, roi, noData, minBandNumber, op);
+                break;
+            case EXP:
+            case NOT:
+            case INVERT:
+            case ABSOLUTE:
+            case LOG:
+                testSingleImageOp(calculated, sources, roi, noData, minBandNumber, op);
+                break;
         }
-        
+
 
         // Disposal of the output image
         calculated.dispose();
     }
 
-    private void testLogicalOp(RenderedOp calculated, RenderedImage[] sources, ROI roi, Range noData,
-            int minBandNumber, Operator op) {
+    private void testLogicalOp(RenderedOp calculated, RenderedImage[] sources, ROI roi,
+                               Range noData,
+                               int minBandNumber, Operator op) {
 
         boolean roiUsed = roi != null;
         boolean noDataUsed = noData != null;
@@ -319,83 +335,84 @@ public class AlgebraTest extends TestBase {
                     isValidData = false;
 
                     boolean isValidROI = !roiUsed || roiUsed && roi.contains(x, y);
-                    if(isValidROI){
+                    if (isValidROI) {
                         switch (dataType) {
-                        case DataBuffer.TYPE_BYTE:
-                            byte valueB = 0;
-                            for(int i = 0; i < numSrc; i++){
-                                sample = sourceRasters[i].getSampleDouble(x, y, b);
-                                if(!noDataUsed || noDataUsed && !noDataDouble.contains(sample)){
-                                    isValidData = true;
-                                    if(i == 0){
-                                        valueB = (byte) sample;
-                                    } else {
-                                        valueB = op.calculate(valueB, (byte) sample);
+                            case DataBuffer.TYPE_BYTE:
+                                byte valueB = 0;
+                                for (int i = 0; i < numSrc; i++) {
+                                    sample = sourceRasters[i].getSampleDouble(x, y, b);
+                                    if (!noDataUsed || noDataUsed && !noDataDouble.contains(sample)) {
+                                        isValidData = true;
+                                        if (i == 0) {
+                                            valueB = (byte) sample;
+                                        } else {
+                                            valueB = op.calculate(valueB, (byte) sample);
+                                        }
                                     }
                                 }
-                            }
-                            valueOld = valueB;
-                            //valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                            value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                            break;
-                        case DataBuffer.TYPE_USHORT:
-                            short valueU = 0;
-                            for(int i = 0; i < numSrc; i++){
-                                sample = sourceRasters[i].getSampleDouble(x, y, b);
-                                if(!noDataUsed || noDataUsed && !noDataDouble.contains(sample)){
-                                    isValidData = true;
-                                    if(i == 0){
-                                        valueU = (short) sample;
-                                    } else {
-                                        valueU = op.calculate(true, valueU, (short) sample);
+                                valueOld = valueB;
+                                //valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) 
+                                // valueOld) & 0xFF);
+                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                break;
+                            case DataBuffer.TYPE_USHORT:
+                                short valueU = 0;
+                                for (int i = 0; i < numSrc; i++) {
+                                    sample = sourceRasters[i].getSampleDouble(x, y, b);
+                                    if (!noDataUsed || noDataUsed && !noDataDouble.contains(sample)) {
+                                        isValidData = true;
+                                        if (i == 0) {
+                                            valueU = (short) sample;
+                                        } else {
+                                            valueU = op.calculate(true, valueU, (short) sample);
+                                        }
                                     }
                                 }
-                            }
-                            valueOld = valueU;
-                            //valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                            break;
-                        case DataBuffer.TYPE_SHORT:
-                            short valueS = 0;
-                            for(int i = 0; i < numSrc; i++){
-                                sample = sourceRasters[i].getSampleDouble(x, y, b);
-                                if(!noDataUsed || noDataUsed && !noDataDouble.contains(sample)){
-                                    isValidData = true;
-                                    if(i == 0){
-                                        valueS = (short) sample;
-                                    } else {
-                                        valueS = op.calculate(false, valueS, (short) sample);
+                                valueOld = valueU;
+                                //valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
+                                break;
+                            case DataBuffer.TYPE_SHORT:
+                                short valueS = 0;
+                                for (int i = 0; i < numSrc; i++) {
+                                    sample = sourceRasters[i].getSampleDouble(x, y, b);
+                                    if (!noDataUsed || noDataUsed && !noDataDouble.contains(sample)) {
+                                        isValidData = true;
+                                        if (i == 0) {
+                                            valueS = (short) sample;
+                                        } else {
+                                            valueS = op.calculate(false, valueS, (short) sample);
+                                        }
                                     }
                                 }
-                            }
-                            valueOld = valueS;
-                            //valueOld = ImageUtil.clampRoundShort(valueOld);
-                            break;
-                        case DataBuffer.TYPE_INT:
-                            int valueI = 0;
-                            for(int i = 0; i < numSrc; i++){
-                                sample = sourceRasters[i].getSampleDouble(x, y, b);
-                                if(!noDataUsed || noDataUsed && !noDataDouble.contains(sample)){
-                                    isValidData = true;
-                                    if(i == 0){
-                                        valueI = (int) sample;
-                                    } else {
-                                        valueI = op.calculate(valueI, (int) sample);
+                                valueOld = valueS;
+                                //valueOld = ImageUtil.clampRoundShort(valueOld);
+                                break;
+                            case DataBuffer.TYPE_INT:
+                                int valueI = 0;
+                                for (int i = 0; i < numSrc; i++) {
+                                    sample = sourceRasters[i].getSampleDouble(x, y, b);
+                                    if (!noDataUsed || noDataUsed && !noDataDouble.contains(sample)) {
+                                        isValidData = true;
+                                        if (i == 0) {
+                                            valueI = (int) sample;
+                                        } else {
+                                            valueI = op.calculate(valueI, (int) sample);
+                                        }
                                     }
                                 }
-                            }
-                            valueOld = valueI;
-                            //valueOld = ImageUtil.clampRoundInt(valueOld);
-                            break;
-                        default:
-                            break;
+                                valueOld = valueI;
+                                //valueOld = ImageUtil.clampRoundInt(valueOld);
+                                break;
+                            default:
+                                break;
                         }
-                        
-                        if(!isValidData){
+
+                        if (!isValidData) {
                             assertEquals(value, destNoData, TOLERANCE);
-                        }else {
+                        } else {
                             assertEquals(value, valueOld, TOLERANCE);
                         }
-                    }else{
+                    } else {
                         assertEquals(value, destNoData, TOLERANCE);
                     }
                 }
@@ -403,8 +420,9 @@ public class AlgebraTest extends TestBase {
         }
     }
 
-    private void testSingleImageOp(RenderedOp calculated, RenderedImage[] sources, ROI roi, Range noData,
-            int minBandNumber, Operator op) {
+    private void testSingleImageOp(RenderedOp calculated, RenderedImage[] sources, ROI roi,
+                                   Range noData,
+                                   int minBandNumber, Operator op) {
 
         boolean roiUsed = roi != null;
         boolean noDataUsed = noData != null;
@@ -444,40 +462,41 @@ public class AlgebraTest extends TestBase {
                     value = upperLeftTile.getSampleDouble(x, y, b);
 
                     valueOld = 0;
-                    
+
                     sample = sourceRasters.getSampleDouble(x, y, b);
 
                     isValidData = (!roiUsed || roiUsed && roi.contains(x, y))
-                            && (!noDataUsed || noDataUsed && !noDataDouble.contains(sample));    
-                    
-                    if(isValidData){
+                            && (!noDataUsed || noDataUsed && !noDataDouble.contains(sample));
+
+                    if (isValidData) {
                         switch (dataType) {
-                        case DataBuffer.TYPE_BYTE:
-                            valueOld = op.calculate((byte)sample);
-                            //valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                            value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                            break;
-                        case DataBuffer.TYPE_USHORT:
-                            valueOld = op.calculate(true, (short)sample)&0xFFFF;
-                            //valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                            break;
-                        case DataBuffer.TYPE_SHORT:
-                            valueOld = op.calculate(false, (short)sample);
-                            valueOld = ImageUtil.clampRoundShort(valueOld);
-                            break;
-                        case DataBuffer.TYPE_INT:
-                            valueOld = op.calculate((int)sample);
-                            valueOld = ImageUtil.clampRoundInt(valueOld);
-                            break;
-                        case DataBuffer.TYPE_FLOAT:
-                            valueOld = op.calculate((float)sample);
-                            //valueOld = (float) sample;
-                            break;
-                        case DataBuffer.TYPE_DOUBLE:
-                            valueOld = op.calculate(sample);
-                            break;
-                        default:
-                            break;
+                            case DataBuffer.TYPE_BYTE:
+                                valueOld = op.calculate((byte) sample);
+                                //valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) 
+                                // valueOld) & 0xFF);
+                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                break;
+                            case DataBuffer.TYPE_USHORT:
+                                valueOld = op.calculate(true, (short) sample) & 0xFFFF;
+                                //valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
+                                break;
+                            case DataBuffer.TYPE_SHORT:
+                                valueOld = op.calculate(false, (short) sample);
+                                valueOld = ImageUtil.clampRoundShort(valueOld);
+                                break;
+                            case DataBuffer.TYPE_INT:
+                                valueOld = op.calculate((int) sample);
+                                valueOld = ImageUtil.clampRoundInt(valueOld);
+                                break;
+                            case DataBuffer.TYPE_FLOAT:
+                                valueOld = op.calculate((float) sample);
+                                //valueOld = (float) sample;
+                                break;
+                            case DataBuffer.TYPE_DOUBLE:
+                                valueOld = op.calculate(sample);
+                                break;
+                            default:
+                                break;
                         }
                         assertEquals(value, valueOld, TOLERANCE);
                     } else {
@@ -487,9 +506,9 @@ public class AlgebraTest extends TestBase {
             }
         }
     }
-    
+
     private void testSum(RenderedOp calculated, RenderedImage[] sources, ROI roi, Range noData,
-            int minBandNumber) {
+                         int minBandNumber) {
 
         boolean roiUsed = roi != null;
         boolean noDataUsed = noData != null;
@@ -550,24 +569,25 @@ public class AlgebraTest extends TestBase {
                             }
                             if (isValidData) {
                                 switch (dataType) {
-                                case DataBuffer.TYPE_BYTE:
-                                    valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                    break;
-                                case DataBuffer.TYPE_USHORT:
-                                    valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                    break;
-                                case DataBuffer.TYPE_SHORT:
-                                    valueOld = ImageUtil.clampRoundShort(valueOld);
-                                    break;
-                                case DataBuffer.TYPE_INT:
-                                    valueOld = ImageUtil.clampRoundInt(valueOld);
-                                    break;
-                                case DataBuffer.TYPE_FLOAT:
-                                    valueOld = (float) valueOld;
-                                    break;
-                                default:
-                                    break;
+                                    case DataBuffer.TYPE_BYTE:
+                                        valueOld =
+                                                (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                        value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                        break;
+                                    case DataBuffer.TYPE_USHORT:
+                                        valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+                                        break;
+                                    case DataBuffer.TYPE_SHORT:
+                                        valueOld = ImageUtil.clampRoundShort(valueOld);
+                                        break;
+                                    case DataBuffer.TYPE_INT:
+                                        valueOld = ImageUtil.clampRoundInt(valueOld);
+                                        break;
+                                    case DataBuffer.TYPE_FLOAT:
+                                        valueOld = (float) valueOld;
+                                        break;
+                                    default:
+                                        break;
                                 }
                                 assertEquals(value, valueOld, TOLERANCE);
                             } else {
@@ -586,26 +606,27 @@ public class AlgebraTest extends TestBase {
                         }
                         if (isValidData) {
                             switch (dataType) {
-                            case DataBuffer.TYPE_BYTE:
-                                valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                break;
-                            case DataBuffer.TYPE_USHORT:
-                                valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                break;
-                            case DataBuffer.TYPE_SHORT:
-                                valueOld = ImageUtil.clampRoundShort(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_INT:
-                                valueOld = ImageUtil.clampRoundInt(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_FLOAT:
-                                valueOld = (float) valueOld;
-                                break;
-                            default:
-                                break;
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
                             }
                             assertEquals(value, valueOld, TOLERANCE);
                         } else {
@@ -617,27 +638,28 @@ public class AlgebraTest extends TestBase {
                                 valueOld += sourceRasters[i].getSampleDouble(x, y, b);
                             }
                             switch (dataType) {
-                            case DataBuffer.TYPE_BYTE:
-                                valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                break;
-                            case DataBuffer.TYPE_USHORT:
-                                valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                
-                                break;
-                            case DataBuffer.TYPE_SHORT:
-                                valueOld = ImageUtil.clampRoundShort(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_INT:
-                                valueOld = ImageUtil.clampRoundInt(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_FLOAT:
-                                valueOld = (float) valueOld;
-                                break;
-                            default:
-                                break;
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
                             }
                             assertEquals(value, valueOld, TOLERANCE);
                         } else {
@@ -648,27 +670,28 @@ public class AlgebraTest extends TestBase {
                             valueOld += sourceRasters[i].getSampleDouble(x, y, b);
                         }
                         switch (dataType) {
-                        case DataBuffer.TYPE_BYTE:
-                            valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                            value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                            break;
-                        case DataBuffer.TYPE_USHORT:
-                            valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                            
-                            break;
-                        case DataBuffer.TYPE_SHORT:
-                            valueOld = ImageUtil.clampRoundShort(valueOld);
-                            
-                            break;
-                        case DataBuffer.TYPE_INT:
-                            valueOld = ImageUtil.clampRoundInt(valueOld);
-                            
-                            break;
-                        case DataBuffer.TYPE_FLOAT:
-                            valueOld = (float) valueOld;
-                            break;
-                        default:
-                            break;
+                            case DataBuffer.TYPE_BYTE:
+                                valueOld =
+                                        (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                break;
+                            case DataBuffer.TYPE_USHORT:
+                                valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                break;
+                            case DataBuffer.TYPE_SHORT:
+                                valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                break;
+                            case DataBuffer.TYPE_INT:
+                                valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                break;
+                            case DataBuffer.TYPE_FLOAT:
+                                valueOld = (float) valueOld;
+                                break;
+                            default:
+                                break;
                         }
                         // Else a simple value comparison is done
                         assertEquals(value, valueOld, TOLERANCE);
@@ -679,7 +702,7 @@ public class AlgebraTest extends TestBase {
     }
 
     private void testSubtract(RenderedOp calculated, RenderedImage[] sources, ROI roi,
-            Range noData, int minBandNumber) {
+                              Range noData, int minBandNumber) {
 
         boolean roiUsed = roi != null;
         boolean noDataUsed = noData != null;
@@ -746,27 +769,28 @@ public class AlgebraTest extends TestBase {
 
                             if (isValidData) {
                                 switch (dataType) {
-                                case DataBuffer.TYPE_BYTE:
-                                    valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                    break;
-                                case DataBuffer.TYPE_USHORT:
-                                    valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                    
-                                    break;
-                                case DataBuffer.TYPE_SHORT:
-                                    valueOld = ImageUtil.clampRoundShort(valueOld);
-                                    
-                                    break;
-                                case DataBuffer.TYPE_INT:
-                                    valueOld = ImageUtil.clampRoundInt(valueOld);
-                                    
-                                    break;
-                                case DataBuffer.TYPE_FLOAT:
-                                    valueOld = (float) valueOld;
-                                    break;
-                                default:
-                                    break;
+                                    case DataBuffer.TYPE_BYTE:
+                                        valueOld =
+                                                (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                        value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                        break;
+                                    case DataBuffer.TYPE_USHORT:
+                                        valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                        break;
+                                    case DataBuffer.TYPE_SHORT:
+                                        valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                        break;
+                                    case DataBuffer.TYPE_INT:
+                                        valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                        break;
+                                    case DataBuffer.TYPE_FLOAT:
+                                        valueOld = (float) valueOld;
+                                        break;
+                                    default:
+                                        break;
                                 }
                                 assertEquals(value, valueOld, TOLERANCE);
                             } else {
@@ -790,27 +814,28 @@ public class AlgebraTest extends TestBase {
                         }
                         if (isValidData) {
                             switch (dataType) {
-                            case DataBuffer.TYPE_BYTE:
-                                valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                break;
-                            case DataBuffer.TYPE_USHORT:
-                                valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                
-                                break;
-                            case DataBuffer.TYPE_SHORT:
-                                valueOld = ImageUtil.clampRoundShort(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_INT:
-                                valueOld = ImageUtil.clampRoundInt(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_FLOAT:
-                                valueOld = (float) valueOld;
-                                break;
-                            default:
-                                break;
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
                             }
                             assertEquals(value, valueOld, TOLERANCE);
                         } else {
@@ -823,27 +848,28 @@ public class AlgebraTest extends TestBase {
                                 valueOld -= sourceRasters[i].getSampleDouble(x, y, b);
                             }
                             switch (dataType) {
-                            case DataBuffer.TYPE_BYTE:
-                                valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                break;
-                            case DataBuffer.TYPE_USHORT:
-                                valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                
-                                break;
-                            case DataBuffer.TYPE_SHORT:
-                                valueOld = ImageUtil.clampRoundShort(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_INT:
-                                valueOld = ImageUtil.clampRoundInt(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_FLOAT:
-                                valueOld = (float) valueOld;
-                                break;
-                            default:
-                                break;
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
                             }
                             assertEquals(value, valueOld, TOLERANCE);
                         } else {
@@ -855,27 +881,28 @@ public class AlgebraTest extends TestBase {
                             valueOld -= sourceRasters[i].getSampleDouble(x, y, b);
                         }
                         switch (dataType) {
-                        case DataBuffer.TYPE_BYTE:
-                            valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                            value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                            break;
-                        case DataBuffer.TYPE_USHORT:
-                            valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                            
-                            break;
-                        case DataBuffer.TYPE_SHORT:
-                            valueOld = ImageUtil.clampRoundShort(valueOld);
-                            
-                            break;
-                        case DataBuffer.TYPE_INT:
-                            valueOld = ImageUtil.clampRoundInt(valueOld);
-                            
-                            break;
-                        case DataBuffer.TYPE_FLOAT:
-                            valueOld = (float) valueOld;
-                            break;
-                        default:
-                            break;
+                            case DataBuffer.TYPE_BYTE:
+                                valueOld =
+                                        (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                break;
+                            case DataBuffer.TYPE_USHORT:
+                                valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                break;
+                            case DataBuffer.TYPE_SHORT:
+                                valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                break;
+                            case DataBuffer.TYPE_INT:
+                                valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                break;
+                            case DataBuffer.TYPE_FLOAT:
+                                valueOld = (float) valueOld;
+                                break;
+                            default:
+                                break;
                         }
                         // Else a simple value comparison is done
                         assertEquals(value, valueOld, TOLERANCE);
@@ -886,7 +913,7 @@ public class AlgebraTest extends TestBase {
     }
 
     private void testMultiply(RenderedOp calculated, RenderedImage[] sources, ROI roi,
-            Range noData, int minBandNumber) {
+                              Range noData, int minBandNumber) {
 
         boolean roiUsed = roi != null;
         boolean noDataUsed = noData != null;
@@ -955,27 +982,28 @@ public class AlgebraTest extends TestBase {
 
                             if (isValidData) {
                                 switch (dataType) {
-                                case DataBuffer.TYPE_BYTE:
-                                    valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                    break;
-                                case DataBuffer.TYPE_USHORT:
-                                    valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                    
-                                    break;
-                                case DataBuffer.TYPE_SHORT:
-                                    valueOld = ImageUtil.clampRoundShort(valueOld);
-                                    
-                                    break;
-                                case DataBuffer.TYPE_INT:
-                                    valueOld = ImageUtil.clampRoundInt(valueOld);
-                                    
-                                    break;
-                                case DataBuffer.TYPE_FLOAT:
-                                    valueOld = (float) valueOld;
-                                    break;
-                                default:
-                                    break;
+                                    case DataBuffer.TYPE_BYTE:
+                                        valueOld =
+                                                (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                        value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                        break;
+                                    case DataBuffer.TYPE_USHORT:
+                                        valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                        break;
+                                    case DataBuffer.TYPE_SHORT:
+                                        valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                        break;
+                                    case DataBuffer.TYPE_INT:
+                                        valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                        break;
+                                    case DataBuffer.TYPE_FLOAT:
+                                        valueOld = (float) valueOld;
+                                        break;
+                                    default:
+                                        break;
                                 }
                                 assertEquals(value, valueOld, TOLERANCE);
                             } else {
@@ -1001,27 +1029,28 @@ public class AlgebraTest extends TestBase {
                         }
                         if (isValidData) {
                             switch (dataType) {
-                            case DataBuffer.TYPE_BYTE:
-                                valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                break;
-                            case DataBuffer.TYPE_USHORT:
-                                valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                
-                                break;
-                            case DataBuffer.TYPE_SHORT:
-                                valueOld = ImageUtil.clampRoundShort(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_INT:
-                                valueOld = ImageUtil.clampRoundInt(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_FLOAT:
-                                valueOld = (float) valueOld;
-                                break;
-                            default:
-                                break;
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
                             }
                             assertEquals(value, valueOld, TOLERANCE);
                         } else {
@@ -1034,27 +1063,28 @@ public class AlgebraTest extends TestBase {
                                 valueOld *= sourceRasters[i].getSampleDouble(x, y, b);
                             }
                             switch (dataType) {
-                            case DataBuffer.TYPE_BYTE:
-                                valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                break;
-                            case DataBuffer.TYPE_USHORT:
-                                valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                
-                                break;
-                            case DataBuffer.TYPE_SHORT:
-                                valueOld = ImageUtil.clampRoundShort(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_INT:
-                                valueOld = ImageUtil.clampRoundInt(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_FLOAT:
-                                valueOld = (float) valueOld;
-                                break;
-                            default:
-                                break;
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
                             }
                             assertEquals(value, valueOld, TOLERANCE);
                         } else {
@@ -1066,27 +1096,28 @@ public class AlgebraTest extends TestBase {
                             valueOld *= sourceRasters[i].getSampleDouble(x, y, b);
                         }
                         switch (dataType) {
-                        case DataBuffer.TYPE_BYTE:
-                            valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                            value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                            break;
-                        case DataBuffer.TYPE_USHORT:
-                            valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                            
-                            break;
-                        case DataBuffer.TYPE_SHORT:
-                            valueOld = ImageUtil.clampRoundShort(valueOld);
-                            
-                            break;
-                        case DataBuffer.TYPE_INT:
-                            valueOld = ImageUtil.clampRoundInt(valueOld);
-                            
-                            break;
-                        case DataBuffer.TYPE_FLOAT:
-                            valueOld = (float) valueOld;
-                            break;
-                        default:
-                            break;
+                            case DataBuffer.TYPE_BYTE:
+                                valueOld =
+                                        (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                break;
+                            case DataBuffer.TYPE_USHORT:
+                                valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                break;
+                            case DataBuffer.TYPE_SHORT:
+                                valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                break;
+                            case DataBuffer.TYPE_INT:
+                                valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                break;
+                            case DataBuffer.TYPE_FLOAT:
+                                valueOld = (float) valueOld;
+                                break;
+                            default:
+                                break;
                         }
                         // Else a simple value comparison is done
                         assertEquals(value, valueOld, TOLERANCE);
@@ -1097,7 +1128,7 @@ public class AlgebraTest extends TestBase {
     }
 
     private void testDivide(RenderedOp calculated, RenderedImage[] sources, ROI roi, Range noData,
-            int minBandNumber) {
+                            int minBandNumber) {
 
         boolean roiUsed = roi != null;
         boolean noDataUsed = noData != null;
@@ -1166,27 +1197,28 @@ public class AlgebraTest extends TestBase {
 
                             if (isValidData) {
                                 switch (dataType) {
-                                case DataBuffer.TYPE_BYTE:
-                                    valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                    break;
-                                case DataBuffer.TYPE_USHORT:
-                                    valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                    
-                                    break;
-                                case DataBuffer.TYPE_SHORT:
-                                    valueOld = ImageUtil.clampRoundShort(valueOld);
-                                    
-                                    break;
-                                case DataBuffer.TYPE_INT:
-                                    valueOld = ImageUtil.clampRoundInt(valueOld);
-                                    
-                                    break;
-                                case DataBuffer.TYPE_FLOAT:
-                                    valueOld = (float) valueOld;
-                                    break;
-                                default:
-                                    break;
+                                    case DataBuffer.TYPE_BYTE:
+                                        valueOld =
+                                                (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                        value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                        break;
+                                    case DataBuffer.TYPE_USHORT:
+                                        valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                        break;
+                                    case DataBuffer.TYPE_SHORT:
+                                        valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                        break;
+                                    case DataBuffer.TYPE_INT:
+                                        valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                        break;
+                                    case DataBuffer.TYPE_FLOAT:
+                                        valueOld = (float) valueOld;
+                                        break;
+                                    default:
+                                        break;
                                 }
                                 assertEquals(value, valueOld, TOLERANCE);
                             } else {
@@ -1212,27 +1244,28 @@ public class AlgebraTest extends TestBase {
                         }
                         if (isValidData) {
                             switch (dataType) {
-                            case DataBuffer.TYPE_BYTE:
-                                valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                break;
-                            case DataBuffer.TYPE_USHORT:
-                                valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                
-                                break;
-                            case DataBuffer.TYPE_SHORT:
-                                valueOld = ImageUtil.clampRoundShort(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_INT:
-                                valueOld = ImageUtil.clampRoundInt(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_FLOAT:
-                                valueOld = (float) valueOld;
-                                break;
-                            default:
-                                break;
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
                             }
                             assertEquals(value, valueOld, TOLERANCE);
                         } else {
@@ -1246,27 +1279,28 @@ public class AlgebraTest extends TestBase {
                                 valueOld /= sample == 0 ? 1 : sample;
                             }
                             switch (dataType) {
-                            case DataBuffer.TYPE_BYTE:
-                                valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                                break;
-                            case DataBuffer.TYPE_USHORT:
-                                valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                                
-                                break;
-                            case DataBuffer.TYPE_SHORT:
-                                valueOld = ImageUtil.clampRoundShort(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_INT:
-                                valueOld = ImageUtil.clampRoundInt(valueOld);
-                                
-                                break;
-                            case DataBuffer.TYPE_FLOAT:
-                                valueOld = (float) valueOld;
-                                break;
-                            default:
-                                break;
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
                             }
                             assertEquals(value, valueOld, TOLERANCE);
                         } else {
@@ -1279,27 +1313,28 @@ public class AlgebraTest extends TestBase {
                             valueOld /= sample == 0 ? 1 : sample;
                         }
                         switch (dataType) {
-                        case DataBuffer.TYPE_BYTE:
-                            valueOld = (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
-                            value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
-                            break;
-                        case DataBuffer.TYPE_USHORT:
-                            valueOld = ImageUtil.clampRoundUShort(valueOld)&0xFFFF;
-                            
-                            break;
-                        case DataBuffer.TYPE_SHORT:
-                            valueOld = ImageUtil.clampRoundShort(valueOld);
-                            
-                            break;
-                        case DataBuffer.TYPE_INT:
-                            valueOld = ImageUtil.clampRoundInt(valueOld);
-                            
-                            break;
-                        case DataBuffer.TYPE_FLOAT:
-                            valueOld = (float) valueOld;
-                            break;
-                        default:
-                            break;
+                            case DataBuffer.TYPE_BYTE:
+                                valueOld =
+                                        (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                break;
+                            case DataBuffer.TYPE_USHORT:
+                                valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+
+                                break;
+                            case DataBuffer.TYPE_SHORT:
+                                valueOld = ImageUtil.clampRoundShort(valueOld);
+
+                                break;
+                            case DataBuffer.TYPE_INT:
+                                valueOld = ImageUtil.clampRoundInt(valueOld);
+
+                                break;
+                            case DataBuffer.TYPE_FLOAT:
+                                valueOld = (float) valueOld;
+                                break;
+                            default:
+                                break;
                         }
                         // Else a simple value comparison is done
                         assertEquals(value, valueOld, TOLERANCE);
@@ -1308,4 +1343,282 @@ public class AlgebraTest extends TestBase {
             }
         }
     }
+
+    private void testMax(RenderedOp calculated, RenderedImage[] sources, ROI roi, Range noData,
+                         int minBandNumber) {
+
+        boolean roiUsed = roi != null;
+        boolean noDataUsed = noData != null;
+
+        // Upper-Left tile indexes
+        int minTileX = calculated.getMinTileX();
+        int minTileY = calculated.getMinTileY();
+        // Raster object
+        Raster upperLeftTile = calculated.getTile(minTileX, minTileY);
+        // Tile bounds
+        int minX = upperLeftTile.getMinX();
+        int minY = upperLeftTile.getMinY();
+        int maxX = upperLeftTile.getWidth() + minX;
+        int maxY = upperLeftTile.getHeight() + minY;
+
+        int numSrc = sources.length;
+
+        // Source Raster Array
+        Raster[] sourceRasters = new Raster[numSrc];
+
+        for (int i = 0; i < numSrc; i++) {
+            sourceRasters[i] = sources[i].getTile(minTileX, minTileY);
+        }
+
+        double valueOld = Double.NEGATIVE_INFINITY;
+
+        double value = 0;
+
+        double sample = 0;
+
+        boolean isValidData = false;
+
+        int dataType = calculated.getSampleModel().getDataType();
+
+        // Cycle on all the tile Bands
+        for (int b = 0; b < minBandNumber; b++) {
+            // Cycle on the y-axis
+            for (int x = minX; x < maxX; x++) {
+                // Cycle on the x-axis
+                for (int y = minY; y < maxY; y++) {
+                    // Calculated value
+                    value = upperLeftTile.getSampleDouble(x, y, b);
+
+                    valueOld = Double.NEGATIVE_INFINITY;
+
+                    isValidData = false;
+
+                    // If no Data are present, no data check is performed
+                    if (noDataUsed && roiUsed) {
+                        if (roi.contains(x, y)) {
+                            for (int i = 0; i < numSrc; i++) {
+                                sample = sourceRasters[i].getSampleDouble(x, y, b);
+                                if (!noDataDouble.contains(sample)) {
+                                    valueOld = Math.max(valueOld, sample);
+                                    isValidData = true;
+                                }
+                            }
+                            if (isValidData) {
+                                switch (dataType) {
+                                    case DataBuffer.TYPE_BYTE:
+                                        valueOld =
+                                                (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                        value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                        break;
+                                    case DataBuffer.TYPE_USHORT:
+                                        valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+                                        break;
+                                    case DataBuffer.TYPE_SHORT:
+                                        valueOld = ImageUtil.clampRoundShort(valueOld);
+                                        break;
+                                    case DataBuffer.TYPE_INT:
+                                        valueOld = ImageUtil.clampRoundInt(valueOld);
+                                        break;
+                                    case DataBuffer.TYPE_FLOAT:
+                                        valueOld = (float) valueOld;
+                                        break;
+                                    default:
+                                        break;
+                                }
+                                assertEquals(value, valueOld, TOLERANCE);
+                            } else {
+                                assertEquals(value, destNoData, TOLERANCE);
+                            }
+                        } else {
+                            assertEquals(value, destNoData, TOLERANCE);
+                        }
+                    } else if (noDataUsed) {
+                        for (int i = 0; i < numSrc; i++) {
+                            sample = sourceRasters[i].getSampleDouble(x, y, b);
+                            if (!noDataDouble.contains(sample)) {
+                                valueOld = Math.max(valueOld, sample);
+                                isValidData = true;
+                            }
+                        }
+                        if (isValidData) {
+                            switch (dataType) {
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
+                            }
+                            assertEquals(value, valueOld, TOLERANCE);
+                        } else {
+                            assertEquals(value, destNoData, TOLERANCE);
+                        }
+                    } else if (roiUsed) {
+                        if (roi.contains(x, y)) {
+                            for (int i = 0; i < numSrc; i++) {
+                                valueOld = Math.max(valueOld, sourceRasters[i].getSampleDouble(x,
+                                        y, b));
+                            }
+                            switch (dataType) {
+                                case DataBuffer.TYPE_BYTE:
+                                    valueOld =
+                                            (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                    value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                    break;
+                                case DataBuffer.TYPE_USHORT:
+                                    valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+                                    break;
+                                case DataBuffer.TYPE_SHORT:
+                                    valueOld = ImageUtil.clampRoundShort(valueOld);
+                                    break;
+                                case DataBuffer.TYPE_INT:
+                                    valueOld = ImageUtil.clampRoundInt(valueOld);
+                                    break;
+                                case DataBuffer.TYPE_FLOAT:
+                                    valueOld = (float) valueOld;
+                                    break;
+                                default:
+                                    break;
+                            }
+                            assertEquals(value, valueOld, TOLERANCE);
+                        } else {
+                            assertEquals(value, destNoData, TOLERANCE);
+                        }
+                    } else {
+                        for (int i = 0; i < numSrc; i++) {
+                            valueOld = Math.max(valueOld, sourceRasters[i].getSampleDouble(x, y,
+                                    b));
+                        }
+                        switch (dataType) {
+                            case DataBuffer.TYPE_BYTE:
+                                valueOld =
+                                        (byte) (((((int) valueOld << 23) >> 31) | (int) valueOld) & 0xFF);
+                                value = (byte) (((((int) value << 23) >> 31) | (int) value) & 0xFF);
+                                break;
+                            case DataBuffer.TYPE_USHORT:
+                                valueOld = ImageUtil.clampRoundUShort(valueOld) & 0xFFFF;
+                                break;
+                            case DataBuffer.TYPE_SHORT:
+                                valueOld = ImageUtil.clampRoundShort(valueOld);
+                                break;
+                            case DataBuffer.TYPE_INT:
+                                valueOld = ImageUtil.clampRoundInt(valueOld);
+                                break;
+                            case DataBuffer.TYPE_FLOAT:
+                                valueOld = (float) valueOld;
+                                break;
+                            default:
+                                break;
+                        }
+                        // Else a simple value comparison is done
+                        assertEquals(value, valueOld, TOLERANCE);
+                    }
+                }
+            }
+        }
+    }
+
+    private void testMin(RenderedOp calculated, RenderedImage[] sources, ROI roi, Range noData,
+                         int minBandNumber) {
+        boolean roiUsed = roi != null;
+        boolean noDataUsed = noData != null;
+
+        // Upper-Left tile indexes
+        int minTileX = calculated.getMinTileX();
+        int minTileY = calculated.getMinTileY();
+        // Raster object
+        Raster upperLeftTile = calculated.getTile(minTileX, minTileY);
+        // Tile bounds
+        int minX = upperLeftTile.getMinX();
+        int minY = upperLeftTile.getMinY();
+        int maxX = upperLeftTile.getWidth() + minX;
+        int maxY = upperLeftTile.getHeight() + minY;
+
+        // Old band value
+        double valueOld = 0;
+        double value = 0;
+        double sample = 0;
+        boolean isValidData = false;
+        int dataType = calculated.getSampleModel().getDataType();
+
+        // Cycle on all the tile Bands
+        for (int b = 0; b < minBandNumber; b++) {
+            // Cycle on the y-axis
+            for (int x = minX; x < maxX; x++) {
+                // Cycle on the x-axis
+                for (int y = minY; y < maxY; y++) {
+                    // Calculated value
+                    value = upperLeftTile.getSampleDouble(x, y, b);
+                    valueOld = Double.POSITIVE_INFINITY;
+                    isValidData = false;
+
+                    // If no Data are present, no data check is performed
+                    if (noDataUsed && roiUsed) {
+                        if (roi.contains(x, y)) {
+                            for (int i = 0; i < sources.length; i++) {
+                                sample = sources[i].getTile(minTileX, minTileY).getSampleDouble(x
+                                        , y, b);
+                                if (!noData.contains(sample)) {
+                                    valueOld = Math.min(valueOld, sample);
+                                    isValidData = true;
+                                }
+                            }
+                            if (isValidData) {
+                                assertEquals(value, valueOld, TOLERANCE);
+                            } else {
+                                assertEquals(value, destNoData, TOLERANCE);
+                            }
+                        } else {
+                            assertEquals(value, destNoData, TOLERANCE);
+                        }
+                    } else if (noDataUsed) {
+                        for (int i = 0; i < sources.length; i++) {
+                            sample = sources[i].getTile(minTileX, minTileY).getSampleDouble(x, y,
+                                    b);
+                            if (!noData.contains(sample)) {
+                                valueOld = Math.min(valueOld, sample);
+                                isValidData = true;
+                            }
+                        }
+                        if (isValidData) {
+                            assertEquals(value, valueOld, TOLERANCE);
+                        } else {
+                            assertEquals(value, destNoData, TOLERANCE);
+                        }
+                    } else if (roiUsed) {
+                        if (roi.contains(x, y)) {
+                            for (int i = 0; i < sources.length; i++) {
+                                valueOld = Math.min(valueOld, sources[i].getTile(minTileX,
+                                        minTileY).getSampleDouble(x, y, b));
+                            }
+                            assertEquals(value, valueOld, TOLERANCE);
+                        } else {
+                            assertEquals(value, destNoData, TOLERANCE);
+                        }
+                    } else {
+                        for (int i = 0; i < sources.length; i++) {
+                            valueOld = Math.min(valueOld,
+                                    sources[i].getTile(minTileX, minTileY).getSampleDouble(x, y,
+                                            b));
+                        }
+                        assertEquals(value, valueOld, TOLERANCE);
+                    }
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Besides adding a min and a max operator, I've also modified a bit the operation behavior.
In particular, the current code was passing nodata into the ops, but the ops have no notion of nodata to start with, and would treat it as a norma value. 

This is strange per se, but lead to tiling issues when combined with the new min/max merge behaviors of mosaic.
Say that a tile has two sources images do not fully overlap, one of them is expanded with nodata (e.g., -9999) causing the min to return -9999, while a nearby tile only matches one source data, and it returns the value from it, causing a sudden output value jump.

With the current approach, there are no sudden jumps, only valid values are used to compute the output keeping the results stable.

