### PR TITLE
BandMerge should use ExtendedBandMergeOpImage when source images are scaled down

### DIFF
--- a/jt-bandmerge/src/main/java/it/geosolutions/jaiext/bandmerge/BandMergeCRIF.java
+++ b/jt-bandmerge/src/main/java/it/geosolutions/jaiext/bandmerge/BandMergeCRIF.java
@@ -106,6 +106,6 @@ public class BandMergeCRIF extends CRIFImpl {
      * @return
      */
     private boolean eqTol(double value, double reference, double tolerance) {
-        return (Math.abs(value) - reference) < tolerance;
+        return Math.abs(Math.abs(value) - reference) < tolerance;
     }
 }

--- a/jt-bandmerge/src/test/java/it/geosolutions/jaiext/bandmerge/BandMergeTest.java
+++ b/jt-bandmerge/src/test/java/it/geosolutions/jaiext/bandmerge/BandMergeTest.java
@@ -835,6 +835,7 @@ public class BandMergeTest extends TestBase {
     public void testExtendedWithIdentityTransform() {
         assertBandMergeImplementation(AffineTransform.getScaleInstance(1 + 1e-12, 1 + 1e-12), BandMergeOpImage.class);
         assertBandMergeImplementation(AffineTransform.getScaleInstance(1 + 1e-6, 1 + 1e-6), ExtendedBandMergeOpImage.class);
+        assertBandMergeImplementation(AffineTransform.getScaleInstance(0.5, 0.5), ExtendedBandMergeOpImage.class);
         assertBandMergeImplementation(AffineTransform.getShearInstance(1e-12, 1e-12), BandMergeOpImage.class);
         assertBandMergeImplementation(AffineTransform.getShearInstance(1e-6, 1e-6), ExtendedBandMergeOpImage.class);
         assertBandMergeImplementation(AffineTransform.getTranslateInstance(1e-12, 1e-12), BandMergeOpImage.class);


### PR DESCRIPTION
Resolves https://github.com/geosolutions-it/jai-ext/issues/299