### PR TITLE
Update jts.version from 1.17.0 to 1.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
     <guava.version>32.0.0-jre</guava.version>
-    <jts.version>1.17.0</jts.version>
+    <jts.version>1.20.0</jts.version>
     <project.version>1.1-SNAPSHOT</project.version>
   </properties>
 


### PR DESCRIPTION
To match the JTS dependency with GeoTools.

see also https://github.com/geotools/geotools/pull/4884 and https://github.com/locationtech/jts/releases/tag/1.20.0