### PR TITLE
Add support for NoData in JiffleOp

### DIFF
--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/runtime/AbstractJiffleRuntime.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/runtime/AbstractJiffleRuntime.java
@@ -189,12 +189,12 @@ public abstract class AbstractJiffleRuntime implements JiffleRuntime {
                 return Double.NaN;
             }
             
-            final double result = iterator.getSampleDouble(posx, posy, band);
+            double result = iterator.getSampleDouble(posx, posy, band);
 
             if (noDataRange != null && noDataRange.contains(result)) {
-                return Double.NaN;
+                result = Double.NaN;
             }
-            
+
             return result;
         }
 

--- a/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleDescriptor.java
+++ b/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleDescriptor.java
@@ -166,9 +166,9 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
                                 + "the number of bands in the output image, must be a positive integer"
                     },
                     {
-                            "ar87Desc",
+                            "arg8Desc",
                             paramNames[8]
-                                    + "  Sources nodata values, if needed "
+                                    + " Sources nodata values, if needed "
                     }
                 },
                 new String[] {RenderedRegistryMode.MODE_NAME}, // supported modes

--- a/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleDescriptor.java
+++ b/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleDescriptor.java
@@ -54,6 +54,7 @@ import javax.media.jai.registry.RenderedRegistryMode;
 
 import it.geosolutions.jaiext.jiffle.runtime.BandTransform;
 import it.geosolutions.jaiext.jiffle.runtime.CoordinateTransform;
+import it.geosolutions.jaiext.range.Range;
 
 /**
  * Jiffle operation.
@@ -72,6 +73,7 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
     static final int SRC_COORDINATE_TRANSFORM_ARG = 5;
     static final int SRC_BAND_TRANSFORM_ARG = 6;
     static final int DEST_BANDS_ARG = 7;
+    static final int NO_DATA_ARG = 8;
 
     public static final String SOURCE_NAMES = "sourceNames";
     public static final String DEST_NAME = "destName";
@@ -81,6 +83,7 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
     public static final String SRC_COORDINATE_TRANSFORMS = "srcCoordinateTransforms";
     public static final String SRC_BAND_TRANSFORMS = "srcBandTransforms";
     public static final String DEST_BANDS = "destBands";
+    public static final String NO_DATA = "noData";
 
     private static final String[] paramNames = {
         SOURCE_NAMES,
@@ -90,7 +93,8 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
         DEST_TYPE,
         SRC_COORDINATE_TRANSFORMS,
         SRC_BAND_TRANSFORMS,
-        DEST_BANDS
+        DEST_BANDS,
+        NO_DATA
     };
 
     private static final Class[] paramClasses = {
@@ -102,10 +106,11 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
         CoordinateTransform[].class,
         BandTransform[].class,
         Integer.class,
+        Range[].class
     };
 
     private static final Object[] paramDefaults = {
-        null, "dest", NO_PARAMETER_DEFAULT, null, DataBuffer.TYPE_DOUBLE, null, null, null
+        null, "dest", NO_PARAMETER_DEFAULT, null, DataBuffer.TYPE_DOUBLE, null, null, null, null
     };
 
     public JiffleDescriptor() {
@@ -143,23 +148,28 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
                                 + "the output data type, as a DataBuffer.TYPE_* constant"
                     },
                     {
-                        "arg6Desc",
+                        "arg5Desc",
                         paramNames[5]
                                 + " (Source coordinate transforms):"
                                 + "the world to image source transforms, if needed"
                     },
                     {
-                        "arg7Desc",
+                        "arg6Desc",
                         paramNames[6]
                                 + " (Source band transforms):"
                                 + "the script to image band transforms, if needed"
                     },
                     {
-                        "arg5Desc",
+                        "arg7Desc",
                         paramNames[7]
                                 + " (Number of output bands, by default the code will try to determine it from the script itself):"
                                 + "the number of bands in the output image, must be a positive integer"
                     },
+                    {
+                            "ar87Desc",
+                            paramNames[8]
+                                    + "  Sources nodata values, if needed "
+                    }
                 },
                 new String[] {RenderedRegistryMode.MODE_NAME}, // supported modes
                 1, // number of sources
@@ -207,6 +217,7 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
             Integer destBands,
             CoordinateTransform[] sourceCoordinateTransforms,
             BandTransform[] sourceBandTransforms,
+            Range[] noData,
             RenderingHints renderingHints) {
         ParameterBlockJAI pb = new ParameterBlockJAI("Jiffle", RenderedRegistryMode.MODE_NAME);
 
@@ -224,6 +235,7 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
         pb.setParameter(SRC_COORDINATE_TRANSFORMS, sourceCoordinateTransforms);
         pb.setParameter(SRC_BAND_TRANSFORMS, sourceBandTransforms);
         pb.setParameter(DEST_BANDS, destBands);
+        pb.setParameter(NO_DATA, noData);
         // JAI operation performed.
         return JAI.create("Jiffle", pb, renderingHints);
     }
@@ -255,6 +267,7 @@ public class JiffleDescriptor extends OperationDescriptorImpl {
                 null,
                 sourceCoordinateTransforms,
                 sourceBandTransforms,
+                null,
                 renderingHints);
     }
 }

--- a/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleOpImage.java
+++ b/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleOpImage.java
@@ -42,26 +42,23 @@
 
 package it.geosolutions.jaiext.jiffleop;
 
+import it.geosolutions.jaiext.jiffle.runtime.BandTransform;
+import it.geosolutions.jaiext.jiffle.runtime.CoordinateTransform;
+import it.geosolutions.jaiext.jiffle.runtime.JiffleIndirectRuntime;
+import it.geosolutions.jaiext.range.NoDataContainer;
+import it.geosolutions.jaiext.range.Range;
+
+import javax.media.jai.ImageLayout;
+import javax.media.jai.OpImage;
+import javax.media.jai.PlanarImage;
 import java.awt.*;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Vector;
 import java.util.stream.Collectors;
-
-import javax.media.jai.ImageLayout;
-import javax.media.jai.OpImage;
-import javax.media.jai.PlanarImage;
-
-import it.geosolutions.jaiext.jiffle.Jiffle;
-import it.geosolutions.jaiext.jiffle.JiffleException;
-import it.geosolutions.jaiext.jiffle.runtime.BandTransform;
-import it.geosolutions.jaiext.jiffle.runtime.CoordinateTransform;
-import it.geosolutions.jaiext.jiffle.runtime.JiffleIndirectRuntime;
-import it.geosolutions.jaiext.range.NoDataContainer;
 
 /**
  * Jiffle operation.
@@ -76,14 +73,24 @@ public class JiffleOpImage extends OpImage {
         RenderedImage image;
         CoordinateTransform coordinateTransform;
         BandTransform bandTransform;
+        Range nodata;
 
         public ImageSpecification(
                 RenderedImage image,
                 CoordinateTransform coordinateTransform,
                 BandTransform bandTransform) {
+            this(image, coordinateTransform, bandTransform, null);
+        }
+
+        public ImageSpecification(
+                RenderedImage image,
+                CoordinateTransform coordinateTransform,
+                BandTransform bandTransform,
+                Range nodata) {
             this.image = image;
             this.coordinateTransform = coordinateTransform;
             this.bandTransform = bandTransform;
+            this.nodata = nodata;
         }
     }
 

--- a/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleRIF.java
+++ b/jt-jiffle/jt-jiffle-op/src/main/java/it/geosolutions/jaiext/jiffleop/JiffleRIF.java
@@ -49,6 +49,7 @@ import java.awt.image.renderable.ParameterBlock;
 import java.awt.image.renderable.RenderedImageFactory;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Vector;
 
 import javax.media.jai.ImageLayout;
@@ -63,6 +64,8 @@ import it.geosolutions.jaiext.jiffle.runtime.CoordinateTransform;
 import it.geosolutions.jaiext.jiffle.runtime.JiffleIndirectRuntime;
 import it.geosolutions.jaiext.jiffle.runtime.JiffleRuntime;
 import it.geosolutions.jaiext.jiffleop.JiffleOpImage.ImageSpecification;
+import it.geosolutions.jaiext.range.NoDataContainer;
+import it.geosolutions.jaiext.range.Range;
 import it.geosolutions.jaiext.utilities.ImageUtilities;
 
 /**
@@ -132,7 +135,24 @@ public class JiffleRIF implements RenderedImageFactory {
             for (Map.Entry<String, ImageSpecification> entry : sourceImages.entrySet()) {
                 String name = entry.getKey();
                 ImageSpecification spec = entry.getValue();
-                runtime.setSourceImage(name, spec.image, spec.coordinateTransform);
+                if (spec.nodata != null) {
+                    RenderedImage image = spec.image;
+                    boolean noDataMatch = false;
+                    Object noDataProperty = image.getProperty(NoDataContainer.GC_NODATA);
+                    if (noDataProperty instanceof NoDataContainer) {
+                        NoDataContainer noData = (NoDataContainer) noDataProperty;
+                        Range range = noData.getAsRange();
+                        noDataMatch = Objects.equals(range, spec.nodata);
+                    }
+                    if (!noDataMatch) {
+                        PlanarImage pi = PlanarImage.wrapRenderedImage(image);
+                        pi.setProperty(NoDataContainer.GC_NODATA, new NoDataContainer(spec.nodata));
+                        image = pi;
+                    }
+                    runtime.setSourceImage(name, image, spec.coordinateTransform);
+                } else {
+                    runtime.setSourceImage(name, spec.image, spec.coordinateTransform);
+                }
                 if (spec.bandTransform != null) {
                     runtime.setSourceImageBandTransform(name, spec.bandTransform);
                 }
@@ -171,6 +191,8 @@ public class JiffleRIF implements RenderedImageFactory {
                         pb.getObjectParameter(JiffleDescriptor.SRC_COORDINATE_TRANSFORM_ARG);
         BandTransform[] bts =
                 (BandTransform[]) pb.getObjectParameter(JiffleDescriptor.SRC_BAND_TRANSFORM_ARG);
+        Range[] nodata =
+                (Range[]) pb.getObjectParameter(JiffleDescriptor.NO_DATA_ARG);
 
         // input-less case (possible, e.g., mandelbrot, surfaces defined by function/algorithm in
         // general)
@@ -182,9 +204,9 @@ public class JiffleRIF implements RenderedImageFactory {
         if (names == null) {
             for (int i = 0; i < sources.size(); i++) {
                 if (i == 0) {
-                    result.put("src", getImageSpecification(sources, cts, bts, i));
+                    result.put("src", getImageSpecification(sources, cts, bts, nodata, i));
                 } else {
-                    result.put("src" + i, getImageSpecification(sources, cts, bts, i));
+                    result.put("src" + i, getImageSpecification(sources, cts, bts, nodata, i));
                 }
             }
         } else {
@@ -198,7 +220,7 @@ public class JiffleRIF implements RenderedImageFactory {
             }
 
             for (int i = 0; i < sources.size(); i++) {
-                result.put(names[i], getImageSpecification(sources, cts, bts, i));
+                result.put(names[i], getImageSpecification(sources, cts, bts, nodata, i));
             }
         }
 
@@ -206,7 +228,7 @@ public class JiffleRIF implements RenderedImageFactory {
     }
 
     private ImageSpecification getImageSpecification(
-            Vector<Object> sources, CoordinateTransform[] cts, BandTransform[] bts, int i) {
+            Vector<Object> sources, CoordinateTransform[] cts, BandTransform[] bts, Range[] nodatas, int i) {
         RenderedImage image = (RenderedImage) sources.get(i);
         CoordinateTransform ct = null;
         if (cts != null) {
@@ -230,8 +252,19 @@ public class JiffleRIF implements RenderedImageFactory {
             }
             bt = bts[i];
         }
+        Range nodata = null;
+        if (nodatas != null) {
+            if (nodatas.length != sources.size()) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Have %d sources, but the nodata argument contains %d entries instead"
+                                        + sources.size()
+                                        + nodatas.length));
+            }
+            nodata = nodatas[i];
+        }
         
-        return new ImageSpecification(image, ct, bt);
+        return new ImageSpecification(image, ct, bt, nodata);
     }
 
     private ImageLayout buildLayout(Rectangle bounds, Dimension tileSize, int dataType, int numBands) {

--- a/jt-jiffle/jt-jiffle-op/src/test/java/it/geosolutions/jaiext/jiffleop/JiffleOpTest.java
+++ b/jt-jiffle/jt-jiffle-op/src/test/java/it/geosolutions/jaiext/jiffleop/JiffleOpTest.java
@@ -20,6 +20,9 @@ package it.geosolutions.jaiext.jiffleop;
 
 import static org.junit.Assert.assertEquals;
 
+import it.geosolutions.jaiext.range.Range;
+import it.geosolutions.jaiext.range.RangeFactory;
+import it.geosolutions.rendered.viewer.RenderedImageBrowser;
 import org.junit.Test;
 
 import java.awt.image.DataBuffer;
@@ -79,6 +82,33 @@ public class JiffleOpTest extends TestBase {
         for(int y = src1.getMinY(); y < src1.getMinY() + src1.getHeight(); y++) {
             for(int x = src1.getMinX(); x < src1.getMinX() + src1.getWidth(); x++) {
                 double expected = srcIter.getSampleDouble(x, y, 0) * 2;
+                double actual = opIter.getSampleDouble(x, y, 0);
+                assertEquals(expected, actual, 0d);
+            }
+        }
+    }
+
+    @Test
+    public void testSumNoData() {
+        RenderedImage src1 = buildTestImage(10, 10);
+        RenderedImage src2 = buildTestImage(10, 10);
+        Range nodata = RangeFactory.create((byte) 5, (byte) 5);
+        RenderedOp op = JiffleDescriptor.create(new RenderedImage[]{src1, src2}, new String[]{"a", "b"}, "res",
+                "res = a + b;", null, DataBuffer.TYPE_DOUBLE, null, null, null, new Range[] {nodata, nodata}, null);
+
+        // check same size and expected
+        assertEquals(src1.getMinX(), op.getMinX());
+        assertEquals(src1.getWidth(), op.getWidth());
+        assertEquals(src1.getMinY(), op.getMinY());
+        assertEquals(src1.getHeight(), op.getHeight());
+        assertEquals(DataBuffer.TYPE_DOUBLE, op.getSampleModel().getDataType());
+
+        RandomIter srcIter = RandomIterFactory.create(src1, null);
+        RandomIter opIter = RandomIterFactory.create(op, null);
+        for(int y = src1.getMinY(); y < src1.getMinY() + src1.getHeight(); y++) {
+            for(int x = src1.getMinX(); x < src1.getMinX() + src1.getWidth(); x++) {
+                double value = srcIter.getSampleDouble(x, y, 0);
+                double expected = value == 5 ? Double.NaN : value * 2;
                 double actual = opIter.getSampleDouble(x, y, 0);
                 assertEquals(expected, actual, 0d);
             }


### PR DESCRIPTION
JAI unwraps RenderedOp containers from sources when initializing a new rendered op: see RenderedOp.createInstance:

```java
protected synchronized PlanarImage createInstance(boolean isNodeRendered) {
        ParameterBlock pb = new ParameterBlock();
        Vector parameters = this.nodeSupport.getParameterBlock().getParameters();
        pb.setParameters(ImageUtil.evaluateParameters(parameters));
        int numSources = this.getNumSources();

        for(int i = 0; i < numSources; ++i) {
            Object source = this.getNodeSource(i);
            Object ai = null;
            if (source instanceof RenderedOp) {
                RenderedOp src = (RenderedOp)source;
                ai = isNodeRendered ? src.getRendering() : src.createInstance();
            } else if (source instanceof CollectionOp) {
                ai = ((CollectionOp)source).getCollection();
            } else if (!(source instanceof RenderedImage) && !(source instanceof Collection)) {
                ai = source;
            } else {
                ai = source;
            }

            pb.addSource(ai);
        }

        RenderedImage rendering = RIFRegistry.create(this.getRegistry(), this.nodeSupport.getOperationName(), pb, this.nodeSupport.getRenderingHints());
        if (rendering == null) {
            throw new RuntimeException(JaiI18N.getString("RenderedOp0"));
        } else {
            PlanarImage instance = PlanarImage.wrapRenderedImage(rendering);
            this.oldHints = this.nodeSupport.getRenderingHints() == null ? null : (RenderingHints)this.nodeSupport.getRenderingHints().clone();
            return instance;
        }
    }
```

That ``src.getRenderin()`` makes it so that an eventual NoData property in the rendered op is lost... and also that's likely why most JAI-EXT ops take a NoData as a parameter, rather than just reading it from inputs.

This PR teaches JiffleOp to do the same, receive the NoData from the parameter block.