### PR TITLE
Upgrade guava from 32.0.0 to 33.4.0

### DIFF
--- a/jt-concurrent-tile-cache/pom.xml
+++ b/jt-concurrent-tile-cache/pom.xml
@@ -15,7 +15,6 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>it.geosolutions.jaiext.utilities</groupId>

--- a/jt-stats/pom.xml
+++ b/jt-stats/pom.xml
@@ -26,7 +26,6 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>it.geosolutions.jaiext.utilities</groupId>

--- a/jt-utilities/pom.xml
+++ b/jt-utilities/pom.xml
@@ -28,12 +28,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>${apache.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <apache.version>2.1</apache.version>
     <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
-    <guava.version>32.0.0-jre</guava.version>
     <jts.version>1.20.0</jts.version>
     <project.version>1.1.28</project.version>
   </properties>
@@ -453,7 +452,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
+        <version>33.4.0-jre</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>


### PR DESCRIPTION
This is just a regular dependency upgrade. jt-utilities doesn't actually need guava and other modules now use the version set in the root POM.