### PR TITLE
Limit loop iterations in Jiffle

### DIFF
--- a/jt-jiffle/jt-jiffle-docs/userguide/language-summary.rst
+++ b/jt-jiffle/jt-jiffle-docs/userguide/language-summary.rst
@@ -267,6 +267,14 @@ There is also a **breakif** statement::
       n++ ;
   }
 
+Maximum loop iterations
+~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to prevent loops from causing excessive resource consumption, Jiffle limits the maximum
+number of loop iterations that will be executed before throwing an exception. This limit is applied
+per pixel so that it is independent of the source image size. The default value is 200 and the
+``it.geosolutions.jaiext.jiffle.maxIterations`` system property can be set to change this limit.
+Setting this property to a negative value will disable this limit.
 
 Functions
 ---------

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/LoopInLiteralList.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/LoopInLiteralList.java
@@ -62,6 +62,7 @@ public class LoopInLiteralList implements Statement {
         w.indent().append("for(Double ").append(loopVariable).append(" : ").append(listLiteral);
         w.append(") {").newLine();
         w.inc();
+        w.line("checkLoopIterations();");
         statement.write(w);
         w.dec();
         w.line("}");

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/LoopInRange.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/LoopInRange.java
@@ -69,6 +69,7 @@ public class LoopInRange implements Statement {
         w.append("; ").append(loopVariable).append(" <= ").append(highVariable);
         w.append("; ").append(loopVariable).append("++) {").newLine();
         w.inc();
+        w.line("checkLoopIterations();");
         statement.write(w);
         w.dec();
         w.line("}");

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/LoopInVariable.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/LoopInVariable.java
@@ -62,6 +62,7 @@ public class LoopInVariable implements Statement {
         w.indent().append("for(Double ").append(loopVariable).append(" : ").append(listVariable);
         w.append(") {").newLine();
         w.inc();
+        w.line("checkLoopIterations();");
         statement.write(w);
         w.dec();
         w.line("}");

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/Script.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/Script.java
@@ -99,6 +99,7 @@ public class Script implements Node {
         }
     }
 
+    @Override
     public void write(SourceWriter w) {
         // class header
         String packageName = "it.geosolutions.jaiext.jiffle.runtime";
@@ -235,6 +236,7 @@ public class Script implements Node {
         w.dec();
         w.line("}");
         w.line("_stk.clear();");
+        w.line("_iterations = 0;");
 
         // centralize the source reads to avoid repeated reads
         readOptimizer.declareRepeatedReads(w);

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/Until.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/Until.java
@@ -62,11 +62,13 @@ public class Until implements Statement {
         return sb.toString();
     }
 
+    @Override
     public void write(SourceWriter w) {
         w.indent().append("while (!_FN.isTrue(");
         condition.write(w);
         w.append(")) {\n");
         w.inc();
+        w.line("checkLoopIterations();");
         statement.write(w);
         w.dec();
         w.line("}");

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/While.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/parser/node/While.java
@@ -62,11 +62,13 @@ public class While implements Statement {
         return sb.toString();
     }
 
+    @Override
     public void write(SourceWriter w) {
         w.indent().append("while (_FN.isTrue(");
         condition.write(w);
         w.append(")) {\n");
         w.inc();
+        w.line("checkLoopIterations();");
         statement.write(w);
         w.dec();
         w.line("}");

--- a/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/runtime/AbstractJiffleRuntime.java
+++ b/jt-jiffle/jt-jiffle-language/src/main/java/it/geosolutions/jaiext/jiffle/runtime/AbstractJiffleRuntime.java
@@ -42,8 +42,6 @@
  */   
 package it.geosolutions.jaiext.jiffle.runtime;
 
-import org.locationtech.jts.geom.Coordinate;
-
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.RenderedImage;
@@ -58,7 +56,6 @@ import it.geosolutions.jaiext.jiffle.Jiffle;
 import it.geosolutions.jaiext.jiffle.JiffleException;
 import it.geosolutions.jaiext.range.NoDataContainer;
 import it.geosolutions.jaiext.range.Range;
-import it.geosolutions.jaiext.range.RangeDouble;
 import it.geosolutions.jaiext.range.RangeFactory;
 
 import javax.media.jai.ROI;
@@ -77,6 +74,10 @@ import javax.media.jai.iterator.RandomIter;
  */
 public abstract class AbstractJiffleRuntime implements JiffleRuntime {
     private static final double EPS = 1.0e-8d;
+
+    public static final String MAX_ITERATIONS_KEY = "it.geosolutions.jaiext.jiffle.maxIterations";
+
+    private static final int DEFAULT_MAX_ITERATIONS = 200;
 
     private enum Dim { XDIM, YDIM };
     
@@ -235,6 +236,10 @@ public abstract class AbstractJiffleRuntime implements JiffleRuntime {
     
     protected CoordinateTransform _defaultTransform;
 
+    private final long _maxIterations;
+
+    protected long _iterations = 0;
+
     public AbstractJiffleRuntime() {
         this(new String[0]);
     }
@@ -251,6 +256,7 @@ public abstract class AbstractJiffleRuntime implements JiffleRuntime {
         _yres = Double.NaN;
         
         _variableNames = variableNames;
+        _maxIterations = Integer.getInteger(MAX_ITERATIONS_KEY, DEFAULT_MAX_ITERATIONS);
     }
     
     /**
@@ -631,6 +637,13 @@ public abstract class AbstractJiffleRuntime implements JiffleRuntime {
      */
     protected int getBands(String imageName) {
         return _images.get(imageName).image.getSampleModel().getNumBands();
+    }
+
+    protected void checkLoopIterations() {
+        this._iterations++;
+        if (this._maxIterations >= 0 && this._iterations > this._maxIterations) {
+            throw new JiffleRuntimeException("Exceeded maximum allowed loop iterations per pixel");
+        }
     }
 
     public abstract void setDefaultBounds();

--- a/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/runtime/LoopTest.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/runtime/LoopTest.java
@@ -56,6 +56,9 @@ import org.junit.Test;
  */
 public class LoopTest extends RuntimeTestBase {
 
+    private static final Exception EXPECTED_EXCEPTION =
+            new JiffleRuntimeException("Exceeded maximum allowed loop iterations per pixel");
+
     @Test
     public void whileLoopWithSimpleStatement() throws Exception {
         System.out.println("   while loop with simple statement");
@@ -377,5 +380,33 @@ public class LoopTest extends RuntimeTestBase {
         };
         
         testScript(script, e);
+    }
+
+    @Test
+    public void whileLoopExceedMaxIterations() throws Exception {
+        System.out.println("   while loop exceeding max iterations");
+        String script = "while (true) dest = 0;";
+        testScript(script, EXPECTED_EXCEPTION);
+    }
+
+    @Test
+    public void untilLoopExceedMaxIterations() throws Exception {
+        System.out.println("   until loop exceeding max iterations");
+        String script = "until (false) dest = 0;";
+        testScript(script, EXPECTED_EXCEPTION);
+    }
+
+    @Test
+    public void foreachLoopExceedMaxIterations() throws Exception {
+        System.out.println("   foreach loop exceeding max iterations");
+        String script =
+                "foreach (i in 0:100) { \n"
+                        + "  foreach (j in 0:100) { \n"
+                        + "    foreach (k in 0:100) { \n"
+                        + "      dest = 0; \n"
+                        + "    } \n"
+                        + "  } \n"
+                        + "}";
+        testScript(script, EXPECTED_EXCEPTION);
     }
 }

--- a/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/runtime/RuntimeTestBase.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/java/it/geosolutions/jaiext/jiffle/runtime/RuntimeTestBase.java
@@ -43,6 +43,7 @@
 package it.geosolutions.jaiext.jiffle.runtime;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import it.geosolutions.jaiext.jiffle.Jiffle;
 
@@ -176,8 +177,8 @@ public abstract class RuntimeTestBase {
             int x = srcImg.getMinX(), y = srcImg.getMinY();
             do {
                 do {
-                    double expected = evaluator.eval(srcIter.getSampleDouble());
                     runtime.evaluate(x, y, actual);
+                    double expected = evaluator.eval(srcIter.getSampleDouble());
                     assertEquals(
                             "Got "
                                     + expected
@@ -257,5 +258,25 @@ public abstract class RuntimeTestBase {
         }
     }
 
+    protected void testScript(String script, Exception expected) throws Exception {
+        RenderedImage srcImg = createSequenceImage();
+        imageParams = new HashMap<>();
+        imageParams.put("dest", Jiffle.ImageRole.DEST);
+        imageParams.put("src", Jiffle.ImageRole.SOURCE);
+
+        // test the direct runtime
+        Jiffle jiffle = new Jiffle(script, imageParams);
+        directRuntimeInstance = jiffle.getRuntimeInstance();
+        Exception actual =
+                assertThrows(expected.getClass(), () -> testDirectRuntime(srcImg, directRuntimeInstance, null));
+        assertEquals(expected.getMessage(), actual.getMessage());
+
+        // and now the indirect one
+        jiffle = new Jiffle(script, imageParams);
+        indirectRuntimeInstance =
+                (JiffleIndirectRuntime) jiffle.getRuntimeInstance(Jiffle.RuntimeModel.INDIRECT);
+        actual = assertThrows(expected.getClass(), () -> testIndirectRuntime(srcImg, indirectRuntimeInstance, null));
+        assertEquals(expected.getMessage(), actual.getMessage());
+    }
 }
 

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/aspect-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/aspect-DIRECT.java
@@ -26,6 +26,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_aData = 0.0;
         double v_bData = 0.0;

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/aspect-INDIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/aspect-INDIRECT.java
@@ -24,6 +24,7 @@ public class JiffleIndirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.run
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_aData = 0.0;
         double v_bData = 0.0;

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/chessboard-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/chessboard-DIRECT.java
@@ -36,6 +36,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_odd_row = _FN.EQ(Math.floor(_y / v_square) % 2.0, 1);
         double v_odd_col = _FN.EQ(Math.floor(_x / v_square) % 2.0, 1);

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/copyBands-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/copyBands-DIRECT.java
@@ -26,10 +26,12 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         final int _lob = (int) (0);
         final int _hi_lob = (int) (getBands("src"));
         for(int v_b = _lob; v_b <= _hi_lob; v_b++) {
+            checkLoopIterations();
             d_dst.write(_x, _y, (int)(v_b), s_src.read(_x, _y, (int)(v_b)));
         }
     }

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/flow-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/flow-DIRECT.java
@@ -26,6 +26,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_minValue = 9999999.0;
         double v_minCol = 0.0;
@@ -35,9 +36,11 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
         final int _lody = (int) (-1);
         final int _hi_lody = (int) (1);
         for(int v_dy = _lody; v_dy <= _hi_lody; v_dy++) {
+            checkLoopIterations();
             final int _lodx = (int) (-1);
             final int _hi_lodx = (int) (1);
             for(int v_dx = _lodx; v_dx <= _hi_lodx; v_dx++) {
+                checkLoopIterations();
                 double v_neighValue = s_dtm.read(_x + v_dx, _y + v_dy, 0);
                 if (_FN.isTrue(_FN.isnull(v_neighValue))) {
                     v_stop = 1.0;

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/interference-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/interference-DIRECT.java
@@ -24,6 +24,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_dx = _x / getWidth();
         double v_dy = _y / getHeight();

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/life-edges-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/life-edges-DIRECT.java
@@ -30,15 +30,18 @@ _outsideValue = 0;
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
         double sv_world__x__y_0 = s_world.read(_x, _y, 0);
 
         double v_n = 0.0;
         final int _loiy = (int) (-1);
         final int _hi_loiy = (int) (1);
         for(int v_iy = _loiy; v_iy <= _hi_loiy; v_iy++) {
+            checkLoopIterations();
             final int _loix = (int) (-1);
             final int _hi_loix = (int) (1);
             for(int v_ix = _loix; v_ix <= _hi_loix; v_ix++) {
+                checkLoopIterations();
                 v_n += s_world.read(_x + v_ix, _y + v_iy, 0);
             }
         }

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/life-toroid-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/life-toroid-DIRECT.java
@@ -26,18 +26,21 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
         double sv_world__x__y_0 = s_world.read(_x, _y, 0);
 
         double v_n = 0.0;
         final int _loiy = (int) (-1);
         final int _hi_loiy = (int) (1);
         for(int v_iy = _loiy; v_iy <= _hi_loiy; v_iy++) {
+            checkLoopIterations();
             double v_yy = _y + v_iy;
             v_yy = (_stk.push(_FN.sign(_FN.LT(v_yy, 0))) == null ? Double.NaN : (_stk.peek() != 0 ? (getHeight() - 1.0) : (v_yy)));
             v_yy = (_stk.push(_FN.sign(_FN.GE(v_yy, getHeight()))) == null ? Double.NaN : (_stk.peek() != 0 ? (0) : (v_yy)));
             final int _loix = (int) (-1);
             final int _hi_loix = (int) (1);
             for(int v_ix = _loix; v_ix <= _hi_loix; v_ix++) {
+                checkLoopIterations();
                 double v_xx = _x + v_ix;
                 v_xx = (_stk.push(_FN.sign(_FN.LT(v_xx, 0))) == null ? Double.NaN : (_stk.peek() != 0 ? (getWidth() - 1.0) : (v_xx)));
                 v_xx = (_stk.push(_FN.sign(_FN.GE(v_xx, getWidth()))) == null ? Double.NaN : (_stk.peek() != 0 ? (0) : (v_xx)));

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/mandelbrot-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/mandelbrot-DIRECT.java
@@ -52,6 +52,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_c_im = v_MaxIm - _y * v_Im_scale;
         double v_c_re = v_MinRe + _x * v_Re_scale;
@@ -60,6 +61,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
         double v_outside = 0.0;
         double v_n = 0.0;
         while (!_FN.isTrue(_FN.GE(v_n, v_MaxIter))) {
+            checkLoopIterations();
             double v_Z_re2 = v_Z_re * v_Z_re;
             double v_Z_im2 = v_Z_im * v_Z_im;
             v_outside = _FN.GT(v_Z_re2 + v_Z_im2, 4);

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/mandelbrot-INDIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/mandelbrot-INDIRECT.java
@@ -50,6 +50,7 @@ public class JiffleIndirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.run
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_c_im = v_MaxIm - _y * v_Im_scale;
         double v_c_re = v_MinRe + _x * v_Re_scale;
@@ -58,6 +59,7 @@ public class JiffleIndirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.run
         double v_outside = 0.0;
         double v_n = 0.0;
         while (!_FN.isTrue(_FN.GE(v_n, v_MaxIter))) {
+            checkLoopIterations();
             double v_Z_re2 = v_Z_re * v_Z_re;
             double v_Z_im2 = v_Z_im * v_Z_im;
             v_outside = _FN.GT(v_Z_re2 + v_Z_im2, 4);

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/ndvi-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/ndvi-DIRECT.java
@@ -28,6 +28,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
         double sv_nir__x__y_0 = s_nir.read(_x, _y, 0);
         double sv_red__x__y_0 = s_red.read(_x, _y, 0);
 

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/ripple-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/ripple-DIRECT.java
@@ -32,6 +32,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_dx = (_x - v_xc) / v_xc;
         double v_dy = (_y - v_yc) / v_yc;

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/squircle-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/squircle-DIRECT.java
@@ -32,6 +32,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_dx = 4.0 * 3.141592653589793 * (0.5 - _x / v_w);
         double v_dy = 4.0 * 3.141592653589793 * (0.5 - _y / v_h);

--- a/jt-jiffle/jt-jiffle-language/src/test/resources/reference/sumBands-DIRECT.java
+++ b/jt-jiffle/jt-jiffle-language/src/test/resources/reference/sumBands-DIRECT.java
@@ -26,6 +26,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
             initImageScopeVars();
         }
         _stk.clear();
+        _iterations = 0;
 
         double v_sum = 0.0;
         double v_goodBands = 0.0;
@@ -33,6 +34,7 @@ public class JiffleDirectRuntimeImpl extends it.geosolutions.jaiext.jiffle.runti
         final int _lob = (int) (0);
         final int _hi_lob = (int) (v_maxBand);
         for(int v_b = _lob; v_b <= _hi_lob; v_b++) {
+            checkLoopIterations();
             double v_value = s_src.read(_x, _y, (int)(v_b));
             if (_FN.isTrue(_FN.NE(v_value, -9999.0))) {
                 v_sum += v_value;


### PR DESCRIPTION
This PR applies a per-pixel limit to the number of loop iterations that will be executed before throwing an exception and adds a system property to configure the limit. The default is 200 which seems generous (and maybe even a little excessive) to me but there may be existing use cases that need a higher limit.