### PR TITLE
Upgrade antlr4 from 4.7.1 to 4.13.2

### DIFF
--- a/jt-jiffle/jt-jiffle-language/pom.xml
+++ b/jt-jiffle/jt-jiffle-language/pom.xml
@@ -17,7 +17,6 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.7.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <test.maxPermSize>512m</test.maxPermSize>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.13.2</junit.version>
+    <antlr4.version>4.13.2</antlr4.version>
     <apache.version>2.1</apache.version>
     <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
@@ -458,7 +459,7 @@
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
-        <version>4.7.1</version>
+        <version>${antlr4.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -519,6 +520,18 @@
     <!-- ========================================================= -->
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr4-maven-plugin</artifactId>
+          <version>${antlr4.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>antlr4</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 	<plugin>
 	 <groupId>org.apache.maven.plugins</groupId>
 	 <artifactId>maven-eclipse-plugin</artifactId>


### PR DESCRIPTION
This is just a regular dependency upgrade. This upgrade will help prevent incompatibilities with GeoServer extensions that use Hibernate after the Jakarta EE migration.