### PR TITLE
Scale operator performs poorly on very large scale ratios and tiling 

### DIFF
--- a/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleOpImage.java
+++ b/jt-scale/src/main/java/it/geosolutions/jaiext/scale/ScaleOpImage.java
@@ -1019,17 +1019,16 @@ public abstract class ScaleOpImage extends GeometricOpImage {
             computableBounds = getBounds();
             // Padding of the input image in order to avoid the call of the getExtendedData() method.
             // Extend the Source image
-            ParameterBlock pb = new ParameterBlock();
-            pb.setSource(source, 0);
             int leftPadding = lpad;
             int topPadding = tpad;
+            // add an extra pixel for left and top padding since the border extender will fill them
+            // with zero otherwise
             if (interp instanceof InterpolationBilinear || interp instanceof InterpolationBicubic) {
-                // add an extrapixel for left and top padding since the border extender will fill them
-                // with zero otherwise
                 leftPadding++;
                 topPadding++;
-
             }
+            ParameterBlock pb = new ParameterBlock();
+            pb.setSource(source, 0);
             pb.set(leftPadding, 0);
             pb.set(rpad, 1);
             pb.set(topPadding, 2);
@@ -1049,6 +1048,7 @@ public abstract class ScaleOpImage extends GeometricOpImage {
             roiRect = new Rectangle(srcROIImage.getMinX() - lpad,
                     srcROIImage.getMinY() - tpad, srcROIImage.getWidth() + lpad + rpad,
                     srcROIImage.getHeight() + tpad + bpad);
+
             // Padding of the input ROI image in order to avoid the call of the getExtendedData() method
             // Calculate the padding between the ROI and the source image padded
             roiBounds = srcROIImage.getBounds();
@@ -1062,6 +1062,14 @@ public abstract class ScaleOpImage extends GeometricOpImage {
             int rightP = deltaX1 > 0 ? deltaX1 : 0;
             int deltaY1 = (srcRect.y + srcRect.height - roiBounds.y - roiBounds.height);
             int bottomP = deltaY1 > 0 ? deltaY1 : 0;
+
+            // add an extra pixel for left and top padding since
+            // the border extender will fill them with zero otherwise
+            if (interp instanceof InterpolationBilinear || interp instanceof InterpolationBicubic) {
+                leftP++;
+                topP++;
+            }
+
             // Extend the ROI image
             ParameterBlock pb = new ParameterBlock();
             pb.setSource(srcROIImage, 0);
@@ -1492,16 +1500,8 @@ public abstract class ScaleOpImage extends GeometricOpImage {
 
             // If the source is fully contained within
             // a tile there is no need to split it any further.
-            if (extender == null) {
-                sources[0] = source0.getData(srcRect);
-            } else {
-                if(source0.getBounds().contains(srcRect)){
-                    sources[0] = source0.getData(srcRect);
-                }else{
-                    sources[0] = extendedIMG.getData(srcRect);
-                }
-
-            }
+            // extract the data
+            sources[0] = getImageData(source0, srcRect);
             // Compute the destination tile.
             computeRect(sources, dest, destRect);
         } else {
@@ -1567,17 +1567,8 @@ public abstract class ScaleOpImage extends GeometricOpImage {
                             wDestRect = wDestRect.intersection(destRect);
 
                             if ((wDestRect.width > 0) && (wDestRect.height > 0)) {
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(wSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(srcRect)){
-                                        sources[0] = source0.getData(srcRect);
-                                    } else {
-                                        sources[0] = extendedIMG.getData(srcRect);
-                                    }
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, wSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, wDestRect);
                             }
@@ -1612,17 +1603,8 @@ public abstract class ScaleOpImage extends GeometricOpImage {
                             hDestRect = hDestRect.intersection(destRect);
 
                             if ((hDestRect.width > 0) && (hDestRect.height > 0)) {
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(hSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(srcRect)){
-                                        sources[0] = source0.getData(srcRect);
-                                    }else{
-                                        sources[0] = extendedIMG.getData(srcRect);
-                                    }
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, hSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, hDestRect);
                             }
@@ -1642,18 +1624,8 @@ public abstract class ScaleOpImage extends GeometricOpImage {
                         newDestRect = newDestRect.intersection(destRect);
 
                         if ((newDestRect.width > 0) && (newDestRect.height > 0)) {
-
-                            // Do the operations with these new rectangles
-                            if (extender == null) {
-                                sources[0] = source0.getData(newSrcRect);
-                            } else {
-                                if(source0.getBounds().contains(srcRect)){
-                                    sources[0] = source0.getData(srcRect);
-                                }else{
-                                    sources[0] = extendedIMG.getData(srcRect);
-                                }
-                            }
-
+                            // extract the data
+                            sources[0] = getImageData(source0, newSrcRect);
                             // Compute the destination tile.
                             computeRect(sources, dest, newDestRect);
                         }
@@ -1707,18 +1679,8 @@ public abstract class ScaleOpImage extends GeometricOpImage {
                             RTSrcRect = mapDestRect(RTDestRect, 0);
 
                             if (RTDestRect.width > 0 && RTDestRect.height > 0) {
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(RTSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(srcRect)){
-                                        sources[0] = source0.getData(srcRect);
-                                    }else{
-                                        sources[0] = extendedIMG.getData(srcRect);
-                                    }
-
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, RTSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, RTDestRect);
                             }
@@ -1757,18 +1719,8 @@ public abstract class ScaleOpImage extends GeometricOpImage {
                             // end
 
                             if (BTDestRect.width > 0 && BTDestRect.height > 0) {
-
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(BTSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(srcRect)){
-                                        sources[0] = source0.getData(srcRect);
-                                    }else{
-                                        sources[0] = extendedIMG.getData(srcRect);
-                                    }
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, BTSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, BTDestRect);
                             }
@@ -1793,17 +1745,8 @@ public abstract class ScaleOpImage extends GeometricOpImage {
                             LRTSrcRect = mapDestRect(LRTDestRect, 0);
 
                             if (LRTDestRect.width > 0 && LRTDestRect.height > 0) {
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(LRTSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(srcRect)){
-                                        sources[0] = source0.getData(srcRect);
-                                    }else{
-                                        sources[0] = extendedIMG.getData(srcRect);
-                                    }
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, LRTSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, LRTDestRect);
                             }
@@ -1815,6 +1758,31 @@ public abstract class ScaleOpImage extends GeometricOpImage {
 
         // Return the written destination raster
         return dest;
+    }
+
+    /**
+     * From the given image source extract the data defined by the given rectangle.
+     * If a border extender is in use, the data might be extracted from the
+     * extended image instead.
+     *
+     * @param source the source image
+     * @param srcRect the rectangle
+     * @return the extracted raster
+     */
+    private Raster getImageData(PlanarImage source, Rectangle srcRect) {
+        // no extender defined: simply forward
+        if (extender == null) {
+            return source.getData(srcRect);
+        } else {
+            // extender defined, but source rectangle entirely within image bounds
+            if(source.getBounds().contains(srcRect)){
+                return source.getData(srcRect);
+            }
+            // extended image access required, forward to pre-computed extended image
+            else{
+                return extendedIMG.getData(srcRect);
+            }
+        }
     }
 
     @Override

--- a/jt-scale/src/test/java/it/geosolutions/jaiext/scale/ScaleOpPerformanceTest.java
+++ b/jt-scale/src/test/java/it/geosolutions/jaiext/scale/ScaleOpPerformanceTest.java
@@ -1,0 +1,232 @@
+package it.geosolutions.jaiext.scale;
+
+import it.geosolutions.jaiext.range.RangeFactory;
+import org.junit.Test;
+
+import javax.media.jai.BorderExtender;
+import javax.media.jai.ImageLayout;
+import javax.media.jai.InterpolationNearest;
+import javax.media.jai.JAI;
+import javax.media.jai.NullOpImage;
+import javax.media.jai.OpImage;
+import javax.media.jai.PlanarImage;
+import javax.media.jai.RasterFactory;
+import javax.media.jai.RenderedOp;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Transparency;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferFloat;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.WritableRaster;
+import java.awt.image.renderable.ParameterBlock;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This test aims to verify the fix for
+ * <a href="https://github.com/geosolutions-it/jai-ext/issues/309">#309</a>.
+ * <p>
+ * There, a massive performance degrade was reported when scaling images
+ * using {@link ScaleOpImage} with large scale ratios. During analysis, it
+ * was observed that {@link ScaleOpImage#computeTile(int, int)} requests
+ * regions from the source image that are way larger than required, in case
+ * border extenders are in use. That leads to massive performance problems,
+ * especially if the source of {@link ScaleOpImage} is a very time-consuming
+ * operator such as Warp.
+ * <p>
+ * The problem lies in {@link ScaleOpImage#computeTile(int, int)} that
+ * correctly calculates the input regions, but then instead passes the
+ * original source rectangle into {@link PlanarImage#getData(Rectangle)}.
+ *
+ * <p>
+ * The way this test works is that it builds a reproducible chain that
+ * shows the problem. Then it intercepts the direct source of the scale
+ * operator by a special implementation on {@link NullOpImage} that
+ * overrides {@link PlanarImage#getData(Rectangle)} in
+ * order to assert on the regions that are passed in by the
+ * {@link ScaleOpImage}.
+ *
+ * @author skalesse
+ * @since 2025-03-10
+ */
+public class ScaleOpPerformanceTest extends TestScale {
+
+    /**
+     * This test asserts the {@link ScaleOpImage} performance
+     * by measuring the time it takes to execute.
+     * While this is not a very stable method, the advantage is
+     * that it shows the problems (and fix) with an
+     * un-altered operation chain.
+     */
+    @Test(timeout = 10000)
+    public void testScaleTilePerformanceUsingTimeout() {
+
+        // create the original source image for this test
+        RenderedImage image  = testImage(6500, 5300);
+        // wrap in a tile image
+        RenderedImage tileImage = tileImage(image, 512, 512);
+
+        // finally, wrap everything in the ScaleOpImage and run the test
+        RenderedImage scaledImage = scaleForTest(
+                tileImage,
+                0.1f, 0.1f,
+                BorderExtender.createInstance(BorderExtender.BORDER_ZERO)
+        );
+
+        scaledImage.getData();
+        ((RenderedOp)scaledImage).dispose();
+    }
+
+    /**
+     * This method asserts the {@link ScaleOpImage} performance by
+     * injecting a modified {@link NullOpImage} as the direct source
+     * of {@link ScaleOpImage}. That way we can directly check the
+     * regions that are passed into the source by {@link ScaleOpImage}.
+     * The advantage of this test is that we don't have to measure
+     * execution times. The disadvantage is that we are altering the
+     * operation chain, which could in theory have side effects.
+     */
+    @Test
+    public void testScaleTilePerformanceUsingAssert() {
+
+        // create the original source image for this test
+        RenderedImage image  = testImage(6500, 5300);
+        // wrap in a tile image
+        RenderedImage tileImage = tileImage(image, 512, 512);
+        // wrap in the 'mock' image that asserts for wrong arguments
+        // passed into getData()
+        RenderedImage testOpImage = new ScaleOpTestImage(tileImage);
+
+        // finally, wrap everything in the ScaleOpImage and run the test
+        RenderedImage scaledImage = scaleForTest(
+                testOpImage,
+                0.1f, 0.1f,
+                BorderExtender.createInstance(BorderExtender.BORDER_ZERO)
+        );
+
+        scaledImage.getData();
+        ((RenderedOp)scaledImage).dispose();
+    }
+
+    /**
+     * Creates the scale operation that is to be tested here.
+     * <p>
+     * Note that this method only takes the arguments that will have an impact on the test.
+     * We do not require translation, background values, no-data ranges, ROI etc. Really,
+     * the only important are the scale factors and border extender.
+     * @param image the source image
+     * @param scaleX the scale-X
+     * @param scaleY the scale-Y
+     * @param borderExtender the border extender (can be {@code null})
+     * @return the scale operation
+     */
+    private static RenderedImage scaleForTest(RenderedImage image, float  scaleX, float scaleY, BorderExtender borderExtender) {
+
+        RenderingHints renderingHints = borderExtender == null ? null: new RenderingHints(
+                JAI.KEY_BORDER_EXTENDER,
+                borderExtender
+        );
+        return ScaleDescriptor.create(
+                image,
+                scaleX, scaleY, 1.f, 1.f,
+                new InterpolationNearest(),
+                null, false,
+                RangeFactory.create(-999.0f, true, -999.0f, true, true),
+                new double[]{255},
+                renderingHints
+        );
+    }
+
+    /**
+     * From the given input image, create a tiled image of the given
+     * tile-width and tile-height.
+     * <p>
+     * The image will be constructed by using the JAI 'format' operator,
+     * passing a new image layout with given tile width/height.
+     * @param image the source image
+     * @param tileWidth the tile width
+     * @param tileHeight the tile height
+     * @return a tiled image ({@link com.sun.media.jai.opimage.CopyOpImage}
+     *         as generated by the 'format' operator)
+     */
+    private static RenderedOp tileImage(RenderedImage image, int tileWidth, int tileHeight) {
+        // create tiled image layout
+        ImageLayout tileLayout = new ImageLayout(image);
+        tileLayout.setTileWidth(tileWidth);
+        tileLayout.setTileHeight(tileHeight);
+        // use 'format' Op to create the wrapper
+        ParameterBlock pb = new ParameterBlock();
+        pb.addSource(image);
+        return JAI.create(
+                "format", pb,
+                new RenderingHints(JAI.KEY_IMAGE_LAYOUT, tileLayout)
+        );
+    }
+
+    /**
+     * Create the original source image for this test.
+     * <p>
+     * The image will be a {@link BufferedImage} of the given size
+     * and {@link DataBuffer#TYPE_FLOAT}. The image data will be a single float value.
+     * @param imageWidth the image width
+     * @param imageHeight the image height
+     * @return a {@link BufferedImage} of type float, filled with a constant value
+     */
+    private static RenderedImage testImage(int imageWidth, int imageHeight) {
+        // create a raster and fill
+        WritableRaster raster = RasterFactory.createBandedRaster(DataBuffer.TYPE_FLOAT, imageWidth, imageHeight, 1, null);
+        float[] dataBuffer = ((DataBufferFloat) raster.getDataBuffer()).getData();
+        for (int rowIdx = 0; rowIdx < imageHeight; rowIdx++) {
+            for (int columnIdx = 0; columnIdx < imageWidth; columnIdx++) {
+                dataBuffer[(imageHeight - rowIdx - 1) * imageWidth + columnIdx] = 32.2f;
+            }
+        }
+        // simple color model
+        int[] dataTypeSize = new int[] {DataBuffer.getDataTypeSize(DataBuffer.TYPE_FLOAT)};
+        ColorSpace colorSpace = ColorSpace.getInstance(ColorSpace.CS_GRAY);
+        ColorModel colorModel = new ComponentColorModel(colorSpace, dataTypeSize, false, true, Transparency.OPAQUE, DataBuffer.TYPE_FLOAT);
+        // create a buffered image
+        return new BufferedImage(colorModel, raster, false, null);
+    }
+
+    /**
+     * The class extends a {@link NullOpImage} and overrides
+     * {@link PlanarImage#getData(Rectangle)} so that
+     * we can assert on requested regions that are larger than the
+     * tile width/height.
+     */
+    static class ScaleOpTestImage extends NullOpImage {
+
+        public ScaleOpTestImage(RenderedImage source) {
+            super(source, new ImageLayout(source),null, OpImage.OP_COMPUTE_BOUND);
+        }
+
+        /**
+         * The method is overridden in order to assert on the regions
+         * that {@link ScaleOpImage} passes to its source when requesting
+         * data in {@link ScaleOpImage#computeTile(int, int)}.
+         *
+         * @param region The rectangular region of this image to be
+         * returned, or <code>null</code>.
+         *
+         * @return calls {@code super.getData()} but asserts on
+         * regions that are larger than tile width/height
+         */
+        @Override
+        public Raster getData(Rectangle region) {
+            assertTrue("Region width "+region.width+" should be smaller/equal than tileWidth " + getTileWidth(),
+                    region.width <= getTileWidth()
+            );
+            assertTrue("Region height "+region.height+" should be smaller/equal than tileHeight " + getTileHeight(),
+                    region.height <= getTileHeight()
+            );
+            return super.getData(region);
+        }
+    }
+}

--- a/jt-scale2/src/main/java/it/geosolutions/jaiext/scale/Scale2OpImage.java
+++ b/jt-scale2/src/main/java/it/geosolutions/jaiext/scale/Scale2OpImage.java
@@ -1026,17 +1026,17 @@ public abstract class Scale2OpImage extends GeometricOpImage {
             computableBounds = getBounds();
             // Padding of the input image in order to avoid the call of the getExtendedData() method.
             // Extend the Source image
-            ParameterBlock pb = new ParameterBlock();
-            pb.setSource(source, 0);
             int leftPadding = lpad;
             int topPadding = tpad;
+            // add an extra pixel for left and top padding since the border extender will fill them
+            // with zero otherwise
             if (interp instanceof InterpolationBilinear || interp instanceof InterpolationBicubic) {
-                // add an extrapixel for left and top padding since the border extender will fill them
-                // with zero otherwise
                 leftPadding++;
                 topPadding++;
 
             }
+            ParameterBlock pb = new ParameterBlock();
+            pb.setSource(source, 0);
             pb.set(leftPadding, 0);
             pb.set(rpad, 1);
             pb.set(topPadding, 2);
@@ -1056,6 +1056,7 @@ public abstract class Scale2OpImage extends GeometricOpImage {
             roiRect = new Rectangle(srcROIImage.getMinX() - lpad,
                     srcROIImage.getMinY() - tpad, srcROIImage.getWidth() + lpad + rpad,
                     srcROIImage.getHeight() + tpad + bpad);
+
             // Padding of the input ROI image in order to avoid the call of the getExtendedData() method
             // Calculate the padding between the ROI and the source image padded
             roiBounds = srcROIImage.getBounds();
@@ -1069,6 +1070,13 @@ public abstract class Scale2OpImage extends GeometricOpImage {
             int rightP = deltaX1 > 0 ? deltaX1 : 0;
             int deltaY1 = (srcRect.y + srcRect.height - roiBounds.y - roiBounds.height);
             int bottomP = deltaY1 > 0 ? deltaY1 : 0;
+            // add an extra pixel for left and top padding since the border extender will fill them
+            // with zero otherwise
+            if (interp instanceof InterpolationBilinear || interp instanceof InterpolationBicubic) {
+                leftP++;
+                topP++;
+
+            }
             // Extend the ROI image
             ParameterBlock pb = new ParameterBlock();
             pb.setSource(srcROIImage, 0);
@@ -1523,16 +1531,7 @@ public abstract class Scale2OpImage extends GeometricOpImage {
 
             // If the source is fully contained within
             // a tile there is no need to split it any further.
-            if (extender == null) {
-                sources[0] = source0.getData(srcRect);
-            } else {
-                if(source0.getBounds().contains(srcRect)){
-                    sources[0] = source0.getData(srcRect);
-                }else{
-                    sources[0] = extendedIMG.getData(srcRect);
-                }
-
-            }
+            sources[0] = getImageData(source0, srcRect);
             // Compute the destination tile.
             computeRect(sources, dest, destRect);
         } else {
@@ -1598,17 +1597,8 @@ public abstract class Scale2OpImage extends GeometricOpImage {
                             wDestRect = wDestRect.intersection(destRect);
 
                             if ((wDestRect.width > 0) && (wDestRect.height > 0)) {
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(wSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(srcRect)){
-                                        sources[0] = source0.getData(wSrcRect);
-                                    } else {
-                                        sources[0] = extendedIMG.getData(srcRect);
-                                    }
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, wSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, wDestRect);
                             }
@@ -1643,17 +1633,8 @@ public abstract class Scale2OpImage extends GeometricOpImage {
                             hDestRect = hDestRect.intersection(destRect);
 
                             if ((hDestRect.width > 0) && (hDestRect.height > 0)) {
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(hSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(srcRect)){
-                                        sources[0] = source0.getData(srcRect);
-                                    }else{
-                                        sources[0] = extendedIMG.getData(srcRect);
-                                    }
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, hSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, hDestRect);
                             }
@@ -1673,18 +1654,8 @@ public abstract class Scale2OpImage extends GeometricOpImage {
                         newDestRect = newDestRect.intersection(destRect);
 
                         if ((newDestRect.width > 0) && (newDestRect.height > 0)) {
-
-                            // Do the operations with these new rectangles
-                            if (extender == null) {
-                                sources[0] = source0.getData(newSrcRect);
-                            } else {
-                                if(source0.getBounds().contains(srcRect)){
-                                    sources[0] = source0.getData(srcRect);
-                                }else{
-                                    sources[0] = extendedIMG.getData(srcRect);
-                                }
-                            }
-
+                            // extract the data
+                            sources[0] = getImageData(source0, newSrcRect);
                             // Compute the destination tile.
                             computeRect(sources, dest, newDestRect);
                         }
@@ -1738,18 +1709,8 @@ public abstract class Scale2OpImage extends GeometricOpImage {
                             RTSrcRect = mapDestRect(RTDestRect, 0);
 
                             if (RTDestRect.width > 0 && RTDestRect.height > 0) {
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(RTSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(RTSrcRect)){
-                                        sources[0] = source0.getData(RTSrcRect);
-                                    }else{
-                                        sources[0] = extendedIMG.getData(RTSrcRect);
-                                    }
-
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, RTSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, RTDestRect);
                             }
@@ -1788,18 +1749,8 @@ public abstract class Scale2OpImage extends GeometricOpImage {
                             // end
 
                             if (BTDestRect.width > 0 && BTDestRect.height > 0) {
-
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(BTSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(BTSrcRect)){
-                                        sources[0] = source0.getData(BTSrcRect);
-                                    }else{
-                                        sources[0] = extendedIMG.getData(BTSrcRect);
-                                    }
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, BTSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, BTDestRect);
                             }
@@ -1824,17 +1775,8 @@ public abstract class Scale2OpImage extends GeometricOpImage {
                             LRTSrcRect = mapDestRect(LRTDestRect, 0);
 
                             if (LRTDestRect.width > 0 && LRTDestRect.height > 0) {
-                                // Do the operations with these new rectangles
-                                if (extender == null) {
-                                    sources[0] = source0.getData(LRTSrcRect);
-                                } else {
-                                    if(source0.getBounds().contains(LRTSrcRect)){
-                                        sources[0] = source0.getData(LRTSrcRect);
-                                    }else{
-                                        sources[0] = extendedIMG.getData(LRTSrcRect);
-                                    }
-                                }
-
+                                // extract the data
+                                sources[0] = getImageData(source0, LRTSrcRect);
                                 // Compute the destination tile.
                                 computeRect(sources, dest, LRTDestRect);
                             }
@@ -1846,6 +1788,31 @@ public abstract class Scale2OpImage extends GeometricOpImage {
 
         // Return the written destination raster
         return dest;
+    }
+
+    /**
+     * From the given image source extract the data defined by the given rectangle.
+     * If a border extender is in use, the data might be extracted from the
+     * extended image instead.
+     *
+     * @param source the source image
+     * @param srcRect the rectangle
+     * @return the extracted raster
+     */
+    private Raster getImageData(PlanarImage source, Rectangle srcRect) {
+        // no extender defined: simply forward
+        if (extender == null) {
+            return source.getData(srcRect);
+        } else {
+            // extender defined, but source rectangle entirely within image bounds
+            if(source.getBounds().contains(srcRect)){
+                return source.getData(srcRect);
+            }
+            // extended image access required, forward to pre-computed extended image
+            else{
+                return extendedIMG.getData(srcRect);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR attempts to fix #309.

The fix is to replace all occurrences of `source0.getData(srcRect)` in `ScaleOpImage` with the individual correct source rectangles. Additionally a fix is needed in the operator's initialization code to add padding of the extended ROI image in order for bi-* interpolations to work correctly. 